### PR TITLE
fix: Dockerfile Rust version and publish verify User-Agent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,11 +55,19 @@ jobs:
         run: |
           set -e
           for crate in aria2-protocol aria2-core aria2-rpc; do
-            version=$(curl -sSf "https://crates.io/api/v1/crates/$crate" | grep -o '"max_version":"[^"]*"' | cut -d'"' -f4)
+            # Retry up to 3 times — crates.io may need a few seconds to index
+            version=""
+            for attempt in 1 2 3; do
+              version=$(curl -sSf -A "aria2-rust-release-pipeline" "https://crates.io/api/v1/crates/$crate" | grep -o '"max_version":"[^"]*"' | cut -d'"' -f4)
+              if [ -n "$version" ]; then break; fi
+              echo "Attempt $attempt: $crate not yet indexed, retrying in 10s..."
+              sleep 10
+            done
             echo "$crate max_version: $version"
             if [ "$version" != "0.2.1" ]; then
               echo "ERROR: $crate is not at version 0.2.1"
               exit 1
             fi
+            sleep 2
           done
           echo "All crates verified at version 0.2.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@
 # ============================================
 # Stage 1: Build
 # ============================================
-# Rust 1.85+ is required for edition = "2024" (stabilized in 1.85).
-FROM rust:1.85-alpine AS builder
+# Rust 1.88+ is required because time@0.3.47 needs rustc 1.88.
+# edition = "2024" was stabilized in 1.85, but transitive deps now demand newer.
+FROM rust:1.88-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
1. **Dockerfile**: Bump rust:1.85-alpine to rust:1.88-alpine. The time@0.3.47 crate (transitive dependency) requires rustc 1.88, and icu_*@2.2.0 requires 1.86. Rust 1.85 is no longer sufficient.

2. **publish.yml**: Add User-Agent header to curl in verify step. crates.io API returns 403 without a User-Agent. Added retry logic (3 attempts, 10s sleep) for crates.io indexing delay after publication.