### PR TITLE
fix: add openssl-libs-static for Docker musl static linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@
 FROM rust:1.88-alpine AS builder
 
 # Install build dependencies
+# openssl-libs-static is required because Rust's musl target links statically
+# by default and needs the .a files (openssl-dev only provides headers + .so).
 RUN apk add --no-cache \
     musl-dev \
     pkgconfig \
     openssl-dev \
+    openssl-libs-static \
     git
 
 WORKDIR /build


### PR DESCRIPTION
## Problem

Docker build in Release workflow (run 29406983854) failed with linker error:
\\\
ld: cannot find -lssl: No such file or directory
ld: have you installed the static version of the ssl library ?
ld: cannot find -lcrypto: No such file or directory
ld: have you installed the static version of the crypto library ?
\\

## Root Cause

Rust's \x86_64-unknown-linux-musl\ target (default for \ust:*-alpine\ images) links statically by default, requiring \.a\ static archive files. Alpine's \openssl-dev\ package only provides headers and \.so\ symlinks — the static archives are in the separate \openssl-libs-static\ package.

## Fix

Add \openssl-libs-static\ to the \pk add\ command in the Dockerfile builder stage.