### PR TITLE
fix: drop arm64 from Docker platforms to avoid QEMU timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,9 +193,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up QEMU for multi-platform builds
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -224,4 +221,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          # arm64 dropped: QEMU emulation takes 60+ minutes for Rust compilation
+          # with C/assembly deps (ring, aws-lc-rs). Use cross-compilation if
+          # arm64 Docker support is needed in the future.
+          platforms: linux/amd64


### PR DESCRIPTION
## Problem

Building for \linux/arm64\ via QEMU emulation takes 60+ minutes for Rust compilation with C/assembly dependencies (\ing\, \ws-lc-rs\). The previous build (run 29415239147) ran for 53+ minutes before being cancelled.

## Root Cause

QEMU user-mode emulation is 5-10x slower than native execution. A Rust project with many C/assembly dependencies takes ~13 minutes on native amd64, which translates to 60-130 minutes under QEMU arm64 emulation — impractical for CI.

## Fix

- Drop \linux/arm64\ from Docker build platforms (keep only \linux/amd64\)
- Remove the QEMU setup step (no longer needed for single-platform build)
- Add comment explaining the decision and how to re-add arm64 via cross-compilation

## Alternative Considered

Cross-compilation (e.g., \cargo build --target aarch64-unknown-linux-musl\) would be much faster but requires setting up the cross-compilation toolchain in the Docker builder stage — more complex and out of scope for this release.