### PR TITLE
chore: remove pull_request trigger from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Change

Remove the \pull_request: branches: [master]\ trigger from \publish.yml\.

## Rationale

- The publish workflow is only meant for tag pushes (\*\)
- The PR trigger caused the dry-run validation to run on every PR (~1.5 min wasted per PR)
- Actual publish steps were already gated with \if: startsWith(github.ref, 'refs/tags/')\, but the dry-run was not — now it only runs on tag pushes, matching the publish steps
- This also eliminates the risk of accidental publishes from PR branches (defense in depth)