### PR TITLE
chore: remove Cargo.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ bindings/python/tests/integration/__pycache__/
 bindings/python/tests/__pycache__/
 *.txt
 *.md
-Cargo.lock


### PR DESCRIPTION
## Change

Remove the \Cargo.lock\ entry from \.gitignore\.

## Rationale

- \Cargo.lock\ is already tracked in git (committed in \59b316\)
- The \.gitignore\ entry was misleading — git ignores \.gitignore\ rules for already-tracked files, so it had no effect
- Per Rust convention, binary projects should commit \Cargo.lock\ for reproducible builds
- Removing the entry makes the intent clear: \Cargo.lock\ is a tracked, first-class file