### PR TITLE
fix: reqwest 0.13.4 + hyper 1.x migration and blocking_read fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "aria2"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aria2-core",
  "aria2-protocol",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "adler32",
  "anyhow",
@@ -198,7 +198,10 @@ dependencies = [
  "futures",
  "hex",
  "hickory-resolver",
- "hyper 0.14.32",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "md5",
  "memmap2",
@@ -229,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -245,7 +248,6 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hex",
- "hyper 0.14.32",
  "md5",
  "mockito",
  "num-bigint-dig",
@@ -269,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aria2-core",
@@ -288,9 +290,9 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "tungstenite",
  "windows-sys 0.59.0",
@@ -386,9 +388,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -401,7 +403,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -419,12 +421,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -786,6 +788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,16 +826,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1260,15 +1262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,21 +1350,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1518,9 +1496,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1555,25 +1535,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1744,17 +1705,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1772,7 +1722,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1808,30 +1758,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -1840,42 +1766,31 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.40",
  "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1884,13 +1799,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2137,6 +2060,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,9 +2331,9 @@ dependencies = [
  "colored 3.1.1",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -2365,23 +2343,6 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2501,48 +2462,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2729,12 +2652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2761,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3012,50 +2985,41 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "async-compression",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-rustls",
- "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tokio-socks",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
- "winreg",
 ]
 
 [[package]]
@@ -3188,6 +3152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,8 +3242,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3378,7 +3388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3603,6 +3613,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,16 +3654,6 @@ checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3736,15 +3752,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3770,27 +3783,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows 0.52.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3960,44 +3952,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.40",
- "tokio",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
-dependencies = [
- "either",
- "futures-util",
- "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -4059,7 +4019,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4075,11 +4035,34 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "async-compression",
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4270,12 +4253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4437,10 +4414,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -4758,16 +4748,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["aria2-rust contributors"]
 license = "GPL-2.0-or-later"
@@ -30,8 +30,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bytes = "1.5"
 async-trait = "0.1"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
-aria2-protocol = { path = "aria2-protocol", version = "0.2.1" }
-aria2-core = { path = "aria2-core", version = "0.2.1" }
+aria2-protocol = { path = "aria2-protocol", version = "0.2.2" }
+aria2-core = { path = "aria2-core", version = "0.2.2" }
 
 [workspace.metadata.release]
 # Release workflow settings
@@ -50,6 +50,7 @@ commit-message = "chore: release v{{version}}"
 # Allow release from main branch only
 allow-branch = ["main", "master"]
 
-# Consistent versioning across workspace
-consolidate-commits = true
-shared-version = true
+# Independent versioning per crate (libraries are published to crates.io
+# individually; the binary has its own program-level version).
+consolidate-commits = false
+shared-version = false

--- a/aria2-core/Cargo.toml
+++ b/aria2-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-core"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -47,17 +47,23 @@ sha2 = "0.10"
 adler32 = "1.2"
 digest = "0.10"
 aria2-protocol = { workspace = true, features = ["bittorrent", "metalink", "sftp"] }
-reqwest = { version = "0.11", features = ["stream", "rustls-tls"], default-features = false }
-# Direct hyper client for the hot HTTP download path. Bypasses reqwest overhead
-# for simple range GETs. The `server` feature is used by the in-crate tests
-# (local hyper server), so hyper is a normal dependency rather than a dev-dep.
-# Note: `hyper-util` / `http-body-util` (which target hyper 1.x) are intentionally
-# NOT added to avoid a dual-hyper-version dependency tree; the v1 client uses
-# hyper 0.14 APIs exclusively.
-hyper = { version = "0.14", features = ["client", "server", "http1", "http2", "stream"] }
+reqwest = { version = "0.13.4", features = ["stream", "rustls", "gzip", "http2"], default-features = false }
+# hyper 1.x is used directly for the hot HTTP download path (HyperDirectClient)
+# and by the in-crate test mock server. reqwest 0.13 also depends on hyper 1.x,
+# so a single hyper version is shared across the dependency tree.
+# `hyper-util` provides client/server connectors and `TokioIo` / `TokioExecutor`.
+# `http-body-util` provides `Full`/`Empty`/`StreamBody` body helpers.
+# `http` provides shared `Request`/`Response`/`StatusCode`/`HeaderMap` types.
+hyper = { version = "1", features = ["http1", "http2"] }
+hyper-util = { version = "0.1", features = ["client", "client-legacy", "server", "http1", "http2", "tokio"] }
+http-body-util = "0.1"
+http = "1"
 # Fully-async DNS resolver (replaces blocking getaddrinfo via tokio::net::lookup_host).
 # `tokio-runtime` enables the async resolver; `default-features = false` avoids pulling in
 # TLS/system-config features we do not need. Hosts-file support is always available on Windows/Unix.
+# Kept at 0.24: reqwest 0.13.4 only requires hickory-resolver 0.26 when its `hickory-dns`
+# feature is enabled (we don't use it). Upgrading to 0.26 would conflict with russh's
+# pinned `rand_core = 0.10.0-rc-3` via aria2-protocol's SFTP support.
 hickory-resolver = { version = "0.24", features = ["tokio-runtime"], default-features = false }
 rand = "0.8"
 regex = "1"

--- a/aria2-core/src/config/option_definitions.rs
+++ b/aria2-core/src/config/option_definitions.rs
@@ -159,7 +159,7 @@ impl super::OptionRegistry {
             name: "log".into(),
             opt_type: OptionType::Path,
             short_name: Some('l'),
-            default_value: OptionValue::Str("-".into()),
+            default_value: OptionValue::None,
             description: "Log file path".into(),
             category: OptionCategory::General,
             ..Default::default()
@@ -178,6 +178,15 @@ impl super::OptionRegistry {
             opt_type: OptionType::Enum,
             default_value: OptionValue::Str("notice".into()),
             description: "Console log level".into(),
+            category: OptionCategory::General,
+            ..Default::default()
+        });
+        self.register(OptionDef {
+            name: "log-backup-count".into(),
+            opt_type: OptionType::Integer,
+            default_value: OptionValue::Int(5),
+            min: Some(1),
+            description: "Number of backup log files to keep".into(),
             category: OptionCategory::General,
             ..Default::default()
         });

--- a/aria2-core/src/constants.rs
+++ b/aria2-core/src/constants.rs
@@ -68,6 +68,7 @@ pub const DEFAULT_SECURE_FALLOC: bool = false;
 pub const CONCURRENT_MIN_FILE_SIZE: usize = 1024 * 1024;
 pub const PROGRESS_UPDATE_BYTES: usize = 256 * 1024;
 pub const DEFAULT_MAX_CONNECTION_PER_SERVER: usize = 4;
+pub const DEFAULT_SPLIT: u16 = 5;
 pub const MIN_SEGMENT_SIZE: usize = 1024 * 256;
 pub const MAX_SEGMENT_SIZE: usize = 1024 * 1024 * 16;
 pub const DEFAULT_SEGMENT_SIZE: usize = 1_048_576;

--- a/aria2-core/src/engine/bt_mse_handshake.rs
+++ b/aria2-core/src/engine/bt_mse_handshake.rs
@@ -335,7 +335,10 @@ impl MseHandshakeManager {
 
     /// Parse remote key exchange payload, compute shared secret
     pub fn process_remote_key_exchange(&mut self, data: &[u8]) -> Result<()> {
-        if data.len() < 8 + 32 {
+        // Minimum payload = 6-byte header (PAD_D + PAD_LEN + Crypto_Pro) + 32-byte
+        // DH public key = 38 bytes. PAD data length is variable (0..=512) and is
+        // validated separately below against the embedded PAD_LEN field.
+        if data.len() < 6 + 32 {
             return Err(Aria2Error::Parse(
                 "Key exchange payload too short".to_string(),
             ));

--- a/aria2-core/src/engine/download_command.rs
+++ b/aria2-core/src/engine/download_command.rs
@@ -557,7 +557,7 @@ impl DownloadCommand {
         self.no_proxy_matcher.as_ref()
     }
 
-    fn should_use_concurrent(&self, total_length: u64, supports_range: bool) -> bool {
+    fn should_use_concurrent(&self, total_length: u64, supports_range: bool, split: u16) -> bool {
         if !supports_range {
             return false;
         }
@@ -565,7 +565,6 @@ impl DownloadCommand {
             return false;
         }
 
-        let split = { self.group.blocking_read().options().split.unwrap_or(1) };
         split > 1
     }
 
@@ -884,8 +883,22 @@ impl DownloadCommand {
         Ok(())
     }
 
-    #[allow(dead_code)] // Reserved for future concurrent download execution strategy
-    async fn execute_concurrent_download(&mut self, uri: &str, total_length: u64) -> Result<()> {
+    async fn execute_concurrent_download(
+        &mut self,
+        uri: &str,
+        total_length: u64,
+        resume_state: &ResumeState,
+        max_retries_per_segment: u32,
+    ) -> Result<()> {
+        // Set total_length on the group immediately so external queries
+        // (RPC status, session persistence) see the correct value from the
+        // start of the concurrent download.
+        {
+            let mut g = self.group.write().await;
+            g.set_total_length(total_length).await;
+            g.set_total_length_atomic(total_length);
+        }
+
         let options = self.group.read().await.options().clone();
         let split = options.split.unwrap_or(1) as usize;
         let max_conn = options
@@ -894,6 +907,8 @@ impl DownloadCommand {
             as usize;
         let seg_size = total_length / split as u64;
         let mut last_progress_update = 0u64; // Track last progress update for batch updates
+        let mut last_speed_update = Instant::now();
+        let mut last_completed = 0u64;
 
         info!(
             "Concurrent download started: split={}, max_conn={}, segment_size={} bytes, total={}",
@@ -903,6 +918,16 @@ impl DownloadCommand {
         let mut manager =
             ConcurrentSegmentManager::new(total_length, vec![uri.to_string()], Some(seg_size));
         manager.set_max_connections_per_mirror(max_conn.min(split));
+        manager.set_max_retries(max_retries_per_segment);
+
+        if resume_state.should_resume {
+            manager.mark_completed_up_to(resume_state.start_offset, resume_state.existing_length);
+            self.completed_bytes = resume_state.start_offset;
+            debug!(
+                "Resume: marked {} bytes as completed, continuing from offset {}",
+                resume_state.existing_length, resume_state.start_offset
+            );
+        }
 
         let url_parsed = reqwest::Url::parse(uri).ok();
         let cookie_hdr = if let Some(ref url) = url_parsed {
@@ -1015,11 +1040,25 @@ impl DownloadCommand {
                         if self.completed_bytes - last_progress_update
                             >= constants::PROGRESS_UPDATE_BYTES as u64
                         {
+                            // Compute speed sample lock-free (refreshed every HTTP_SPEED_UPDATE_INTERVAL_MS).
+                            let elapsed = last_speed_update.elapsed();
+                            let speed = if elapsed.as_millis()
+                                >= constants::HTTP_SPEED_UPDATE_INTERVAL_MS as u128
+                            {
+                                let delta = self.completed_bytes - last_completed;
+                                let s = (delta as f64 / elapsed.as_secs_f64()) as u64;
+                                last_speed_update = Instant::now();
+                                last_completed = self.completed_bytes;
+                                s
+                            } else {
+                                0
+                            };
+
                             if let Some(ref sender) = self.progress_sender {
                                 // Lock-free: send via channel, engine aggregator applies to RequestGroup.
                                 let _ = sender.send(ProgressUpdate {
                                     completed_bytes: self.completed_bytes,
-                                    download_speed: 0,
+                                    download_speed: speed,
                                     upload_speed: 0,
                                 });
                             } else {
@@ -1028,6 +1067,22 @@ impl DownloadCommand {
                                 g.update_progress(self.completed_bytes).await;
                                 // Export to atomic fields for session persistence
                                 g.set_completed_length(self.completed_bytes);
+                                if speed > 0 {
+                                    g.update_speed(speed, 0).await;
+                                    // Update cached download speed for session persistence
+                                    g.set_download_speed_cached(speed);
+                                }
+                            }
+
+                            // Record performance metrics (minimal overhead, lock-free).
+                            if speed > 0 {
+                                self.atomic_metrics.record_throughput(speed);
+                                if let Some(ref monitor) = self.perf_monitor {
+                                    let metrics =
+                                        Metrics::new(speed, elapsed.as_millis() as u64, 0, 0)
+                                            .with_label("download_speed");
+                                    monitor.record_metric("download_speed", metrics);
+                                }
                             }
                             last_progress_update = self.completed_bytes;
                         }
@@ -1157,8 +1212,8 @@ impl DownloadCommand {
             )
             .await
         } else {
-            // Fallback to single-URI concurrent download
-            self.execute_concurrent_download_single_uri(
+            // Single URI: use FuturesUnordered-based concurrent download
+            self.execute_concurrent_download(
                 uri,
                 total_length,
                 resume_state,
@@ -1435,118 +1490,6 @@ impl DownloadCommand {
         Ok(())
     }
 
-    /// Execute concurrent download for a single URI (fallback method).
-    async fn execute_concurrent_download_single_uri(
-        &mut self,
-        uri: &str,
-        total_length: u64,
-        resume_state: &ResumeState,
-        max_retries_per_segment: u32,
-    ) -> Result<()> {
-        let split = self.group.read().await.options().split.unwrap_or(1) as u64;
-        let segment_size = total_length.div_ceil(split);
-        let mut manager =
-            ConcurrentSegmentManager::new(total_length, vec![uri.to_string()], Some(segment_size));
-        manager.set_max_retries(max_retries_per_segment);
-
-        if resume_state.should_resume {
-            manager.mark_completed_up_to(resume_state.start_offset, resume_state.existing_length);
-        }
-
-        let mut writer = self.create_writer(total_length);
-
-        while manager.has_pending_segments() || !manager.is_complete() {
-            while let Some((seg_idx, offset, length)) = manager.next_pending_segment() {
-                let seg_idx_u32 = seg_idx;
-                info!(
-                    "Starting segment {} download: offset={}, size={}",
-                    seg_idx, offset, length
-                );
-                let downloader = HttpSegmentDownloader::new(&self.client, self.use_hyper);
-                let seg_start = Instant::now();
-                let result = downloader
-                    .download_range(uri, offset, length, None, &self.headers)
-                    .await;
-
-                match result {
-                    Ok(data) => {
-                        let elapsed = seg_start.elapsed();
-                        let speed = if elapsed.as_secs_f64() > 0.0 {
-                            (data.len() as f64 / elapsed.as_secs_f64()) as u64
-                        } else {
-                            0
-                        };
-                        debug!(
-                            "Segment {} complete: {} bytes, speed={} B/s",
-                            seg_idx,
-                            data.len(),
-                            speed
-                        );
-
-                        // Zero-copy write: writer consumes the original Bytes;
-                        // manager gets a cheap Arc-refcount-bumped clone.
-                        let data_for_manager = data.clone();
-                        writer.write_bytes_at(offset, data).await.map_err(|e| {
-                            Aria2Error::Fatal(crate::error::FatalError::Config(format!(
-                                "Write failed: {}",
-                                e
-                            )))
-                        })?;
-
-                        // Report completion with speed feedback
-                        manager.report_segment_complete(
-                            seg_idx_u32,
-                            data_for_manager,
-                            speed,
-                            false,
-                        );
-                    }
-                    Err(e) => {
-                        warn!("Segment {} download failed: {}", seg_idx, e);
-                        manager
-                            .report_segment_failed(seg_idx_u32, constants::HTTP_DEFAULT_ERROR_CODE);
-                    }
-                }
-
-                self.completed_bytes = manager.completed_bytes();
-                let g = self.group.write().await;
-                g.update_progress(self.completed_bytes).await;
-                // Export to atomic fields for session persistence
-                g.set_completed_length(self.completed_bytes);
-            }
-
-            if manager.is_complete() {
-                break;
-            }
-
-            if manager.has_permanently_failed_segments() {
-                error!("Permanently failed download segments exist");
-                return Err(Aria2Error::Recoverable(
-                    RecoverableError::TemporaryNetworkFailure {
-                        message: "Some download segments permanently failed".into(),
-                    },
-                ));
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-
-        writer.flush().await.map_err(|e| {
-            Aria2Error::Fatal(crate::error::FatalError::Config(format!(
-                "Flush failed: {}",
-                e
-            )))
-        })?;
-        self.completed_bytes = manager.completed_bytes();
-        let mut g = self.group.write().await;
-        g.set_total_length(self.completed_bytes).await;
-        // Export to atomic fields for session persistence
-        g.set_total_length_atomic(self.completed_bytes);
-        g.set_completed_length(self.completed_bytes);
-        g.complete().await?;
-        Ok(())
-    }
-
     /// Save server statistics to the default location.
     async fn save_server_stats(&self) -> std::result::Result<usize, String> {
         // In a real implementation, this would save to a configured path
@@ -1639,7 +1582,16 @@ impl Command for DownloadCommand {
         }
         let head_resp = head_req.send().await.ok();
         let (total_length, supports_range) = if let Some(ref resp) = head_resp {
-            let tl = resp.content_length().unwrap_or(0);
+            // Use the Content-Length header directly instead of resp.content_length()
+            // because reqwest returns None for HEAD responses (it uses the actual body
+            // length, not the header value — documented behaviour in 0.11 through 0.13).
+            // Reading the header directly works correctly for both HEAD and GET responses.
+            let tl = resp
+                .headers()
+                .get(reqwest::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
             let sr = resp
                 .headers()
                 .get("Accept-Ranges")
@@ -1694,8 +1646,9 @@ impl Command for DownloadCommand {
             }
 
             let options = self.group.read().await.options().clone();
+            let split = options.split.unwrap_or(constants::DEFAULT_SPLIT);
 
-            if self.should_use_concurrent(total_length, supports_range) {
+            if self.should_use_concurrent(total_length, supports_range, split) {
                 if resume_state.should_resume {
                     info!(
                         "Concurrent mode + resume: existing {} bytes, continuing from offset {}",

--- a/aria2-core/src/engine/metalink_download_command.rs
+++ b/aria2-core/src/engine/metalink_download_command.rs
@@ -257,7 +257,17 @@ impl MetalinkDownloadCommand {
             ))));
         }
 
-        let total_length = response.content_length().unwrap_or(0) as u64;
+        // Read Content-Length from the header directly instead of using
+        // response.content_length(), which returns the *body* size. For chunked
+        // transfer encoding or proxy-modified responses the body size may differ
+        // from the advertised header value. The header value is what the server
+        // advertised and is consistent with download_command.rs's approach.
+        let total_length = response
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0);
 
         {
             let mut g = self.group.write().await;

--- a/aria2-core/src/http/hyper_client.rs
+++ b/aria2-core/src/http/hyper_client.rs
@@ -1,31 +1,34 @@
 //! Direct hyper HTTP client for the hot download path.
 //!
 //! Bypasses reqwest overhead for simple HTTP range GETs by using hyper's
-//! `Client` with a tuned `HttpConnector`. The connector enables hyper's
-//! built-in Happy Eyeballs racing (`set_happy_eyeballs_timeout`) so IPv6/IPv4
-//! connects are raced with a 250ms IPv6 head start, matching the behaviour of
-//! `crate::http::happy_eyeballs::connect_happy_eyeballs`.
+//! `Client` (via `hyper-util`) with a tuned `HttpConnector`. The connector
+//! enables hyper's built-in Happy Eyeballs racing (`set_happy_eyeballs_timeout`)
+//! so IPv6/IPv4 connects are raced with a 250ms IPv6 head start, matching the
+//! behaviour of `crate::http::happy_eyeballs::connect_happy_eyeballs`.
 //!
 //! For proxy / complex-auth / HTTPS-with-custom-TLS paths, reqwest is still
 //! used (see `client_pool.rs` and `connection.rs`); this module does NOT remove
 //! reqwest.
 //!
-//! # TODO (future work)
-//! - Implement a custom `hyper::service::Service` connector that delegates to
-//!   `crate::http::happy_eyeballs::connect_happy_eyeballs` for full control
-//!   over the dual-stack race (including custom DNS via `hickory-resolver`).
-//! - Wire `HyperDirectClient::download_range` into
-//!   `HttpSegmentDownloader::download_range` when no proxy is configured
-//!   (the "hot path").
+//! # hyper 1.x notes
+//! hyper 1.x removed `hyper::Body`, `hyper::client::Client`, and
+//! `hyper::server::Server`. This module uses:
+//! - `hyper_util::client::legacy::Client` for the pooled HTTP client
+//! - `http_body_util::{Full, Empty}` for request/response bodies
+//! - `http_body_util::BodyExt` for body frame iteration
+//! - `hyper::body::Incoming` for received response bodies
 
+use std::pin::Pin;
 use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
 use futures::stream::Stream;
-use hyper::StatusCode;
-use hyper::body::HttpBody;
-use hyper::client::{Client, HttpConnector};
+use http::StatusCode;
+use http_body_util::{BodyExt, Full};
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
 use tracing::{debug, warn};
 
 use crate::error::{Aria2Error, FatalError, RecoverableError, Result};
@@ -46,7 +49,7 @@ const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 /// when a caller passes a very large `length` hint).
 const MAX_INITIAL_CAPACITY: u64 = 4 * 1024 * 1024;
 
-/// A lightweight HTTP client using hyper directly.
+/// A lightweight HTTP client using hyper directly (via hyper-util).
 ///
 /// Intended for the hot download path: simple HTTP range GETs with no proxy
 /// and no complex auth. It avoids reqwest's abstraction overhead (middleware,
@@ -57,7 +60,7 @@ const MAX_INITIAL_CAPACITY: u64 = 4 * 1024 * 1024;
 /// in; for the plain-HTTP hot path this client is sufficient. HTTPS fallback
 /// to reqwest remains available.
 pub struct HyperDirectClient {
-    client: Client<HttpConnector, hyper::Body>,
+    client: Client<HttpConnector, Full<Bytes>>,
 }
 
 impl HyperDirectClient {
@@ -74,7 +77,7 @@ impl HyperDirectClient {
         // DNS resolver).
         connector.set_happy_eyeballs_timeout(Some(HAPPY_EYEBALLS_HEAD_START));
 
-        let client = Client::builder()
+        let client = Client::builder(TokioExecutor::new())
             .pool_idle_timeout(Some(POOL_IDLE_TIMEOUT))
             .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST)
             .build(connector);
@@ -146,18 +149,17 @@ impl HyperDirectClient {
             _ => {}
         }
 
-        // Accumulate body chunks into a BytesMut, then freeze to Bytes.
+        // Accumulate body into a BytesMut, then freeze to Bytes.
+        // hyper 1.x uses `BodyExt::collect()` which gathers all frames into
+        // a single `Collected<Bytes>` that can be converted to `Bytes`.
         let initial_cap = length.unwrap_or(0).min(MAX_INITIAL_CAPACITY) as usize;
         let mut buf = bytes::BytesMut::with_capacity(initial_cap);
-        let mut body = response.into_body();
-        while let Some(chunk) = body.data().await {
-            let chunk = chunk.map_err(|e| {
-                Aria2Error::Recoverable(RecoverableError::TemporaryNetworkFailure {
-                    message: format!("hyper stream read error: {e}"),
-                })
-            })?;
-            buf.extend_from_slice(&chunk);
-        }
+        let collected = response.into_body().collect().await.map_err(|e| {
+            Aria2Error::Recoverable(RecoverableError::TemporaryNetworkFailure {
+                message: format!("hyper stream read error: {e}"),
+            })
+        })?;
+        buf.extend_from_slice(&collected.to_bytes());
 
         // An empty body is only an error when a concrete non-zero length was
         // requested (mirrors `HttpSegmentDownloader::download_range`).
@@ -180,18 +182,19 @@ impl HyperDirectClient {
     ///
     /// Status handling here is stricter than `download_range`: only `2xx` and
     /// `206` are accepted; any other status is an error before streaming begins.
+    ///
+    /// The returned stream is boxed because hyper 1.x body types (`Incoming`
+    /// vs `Empty`) are not unifyable without type erasure.
     pub async fn download_range_stream(
         &self,
         url: &str,
         offset: u64,
         length: Option<u64>,
-    ) -> Result<impl Stream<Item = std::result::Result<Bytes, std::io::Error>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send>>>
+    {
         // Zero-length explicit range: return an empty stream without a request.
-        // `hyper::Body::empty()` is a `Stream` that yields nothing immediately,
-        // so mapping it produces the same concrete `Map<hyper::Body, _>` type
-        // as the main path (both use the named `map_body_chunk` function).
         if matches!(length, Some(0)) {
-            return Ok(hyper::Body::empty().map(map_body_chunk));
+            return Ok(Box::pin(futures::stream::empty()));
         }
 
         let range_header = build_range_header(offset, length);
@@ -212,9 +215,15 @@ impl HyperDirectClient {
             }));
         }
 
-        // `hyper::Body` implements `Stream<Item = Result<Bytes, hyper::Error>>`
-        // with the `stream` feature; map the error type to `std::io::Error`.
-        Ok(response.into_body().map(map_body_chunk))
+        // Convert the hyper 1.x body into a `Stream<Item = Result<Bytes, _>>`
+        // via `BodyExt::into_data_stream()`, then map the error type.
+        let stream = response
+            .into_body()
+            .into_data_stream()
+            .map(|res| {
+                res.map_err(|e| std::io::Error::other(format!("hyper stream error: {e}")))
+            });
+        Ok(Box::pin(stream))
     }
 }
 
@@ -246,40 +255,30 @@ fn build_range_header(offset: u64, length: Option<u64>) -> String {
 }
 
 /// Build a `GET` request with the given Range header and the project user-agent.
-fn build_range_request(url: &str, range_header: &str) -> Result<hyper::Request<hyper::Body>> {
-    let uri: hyper::Uri = url
+fn build_range_request(url: &str, range_header: &str) -> Result<http::Request<Full<Bytes>>> {
+    let uri: http::Uri = url
         .parse()
         .map_err(|e| Aria2Error::Parse(format!("invalid URL {url:?}: {e}")))?;
 
-    hyper::Request::builder()
+    http::Request::builder()
         .method("GET")
         .uri(uri)
         .header("range", range_header)
         .header("user-agent", crate::constants::USER_AGENT)
-        .body(hyper::Body::empty())
+        .body(Full::new(Bytes::new()))
         .map_err(|e| Aria2Error::Io(format!("failed to build request: {e}")))
-}
-
-/// Convert a hyper body chunk result to `Result<Bytes, std::io::Error>`.
-///
-/// Defined as a named function (not a closure) so that `body.map(map_body_chunk)`
-/// at multiple call sites produces the *same* concrete `Map<hyper::Body, _>`
-/// type, allowing a single `impl Stream` return type to unify across the
-/// zero-length short-circuit and the normal streaming path.
-fn map_body_chunk(
-    res: std::result::Result<Bytes, hyper::Error>,
-) -> std::result::Result<Bytes, std::io::Error> {
-    res.map_err(|e| std::io::Error::other(format!("hyper stream error: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::server::Server;
-    use hyper::service::{make_service_fn, service_fn};
-    use hyper::{Body, Request, Response, StatusCode};
+    use hyper::body::Incoming;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
+    use hyper_util::rt::TokioIo;
     use std::convert::Infallible;
     use std::net::SocketAddr;
+    use tokio::net::TcpListener;
 
     /// Test payload served by the local server (11 bytes: "hello world").
     const PAYLOAD: &[u8] = b"hello world";
@@ -290,7 +289,9 @@ mod tests {
     /// * `bytes=6-`    -> `206` with "world"
     /// * out-of-range  -> `416`
     /// * no Range      -> `200` with full payload
-    async fn handle(req: Request<Body>) -> std::result::Result<Response<Body>, Infallible> {
+    async fn handle(
+        req: http::Request<Incoming>,
+    ) -> std::result::Result<http::Response<Full<Bytes>>, Infallible> {
         let range = req
             .headers()
             .get("range")
@@ -302,10 +303,10 @@ mod tests {
             let start: usize = start_s.parse().unwrap_or(0);
 
             if start >= PAYLOAD.len() {
-                return Ok(Response::builder()
-                    .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                return Ok(http::Response::builder()
+                    .status(http::StatusCode::RANGE_NOT_SATISFIABLE)
                     .header("content-range", format!("bytes */{}", PAYLOAD.len()))
-                    .body(Body::empty())
+                    .body(Full::new(Bytes::new()))
                     .unwrap());
             }
 
@@ -317,27 +318,44 @@ mod tests {
             };
             let slice = &PAYLOAD[start..=end];
 
-            return Ok(Response::builder()
-                .status(StatusCode::PARTIAL_CONTENT)
+            return Ok(http::Response::builder()
+                .status(http::StatusCode::PARTIAL_CONTENT)
                 .header(
                     "content-range",
                     format!("bytes {}-{}/{}", start, end, PAYLOAD.len()),
                 )
-                .body(Body::from(slice.to_vec()))
+                .body(Full::new(Bytes::copy_from_slice(slice)))
                 .unwrap());
         }
 
-        Ok(Response::new(Body::from(PAYLOAD.to_vec())))
+        Ok(http::Response::new(Full::new(Bytes::copy_from_slice(
+            PAYLOAD,
+        ))))
     }
 
-    /// Spawn a local hyper server on an ephemeral port and return its address.
+    /// Spawn a local hyper 1.x server on an ephemeral port and return its address.
+    ///
+    /// Uses `tokio::net::TcpListener` + `hyper::server::conn::http1::Builder`
+    /// (the hyper 1.x replacement for the removed `hyper::server::Server`).
     async fn spawn_server() -> SocketAddr {
         let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-        let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
-        let server = Server::bind(&addr).serve(make_svc);
-        let local_addr = server.local_addr();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
         tokio::spawn(async move {
-            let _ = server.await;
+            loop {
+                // Accept connections until the listener is dropped (test ends).
+                let (stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(_) => break,
+                };
+                let io = TokioIo::new(stream);
+                tokio::spawn(async move {
+                    let _ = http1::Builder::new()
+                        .serve_connection(io, service_fn(handle))
+                        .await;
+                });
+            }
         });
         local_addr
     }

--- a/aria2-core/src/http/hyper_client.rs
+++ b/aria2-core/src/http/hyper_client.rs
@@ -220,9 +220,7 @@ impl HyperDirectClient {
         let stream = response
             .into_body()
             .into_data_stream()
-            .map(|res| {
-                res.map_err(|e| std::io::Error::other(format!("hyper stream error: {e}")))
-            });
+            .map(|res| res.map_err(|e| std::io::Error::other(format!("hyper stream error: {e}"))));
         Ok(Box::pin(stream))
     }
 }

--- a/aria2-core/src/lib.rs
+++ b/aria2-core/src/lib.rs
@@ -108,8 +108,6 @@ pub use request::request_group::{DownloadStatus, RUNTIME_CHANGEABLE_OPTIONS};
 #[cfg(test)]
 mod integration_tests_j2_j5;
 
-
-
 /// Initialize the logging subsystem with optional file output.
 ///
 /// Sets up `tracing-subscriber` with console output (colorized) and optionally

--- a/aria2-core/src/lib.rs
+++ b/aria2-core/src/lib.rs
@@ -108,12 +108,17 @@ pub use request::request_group::{DownloadStatus, RUNTIME_CHANGEABLE_OPTIONS};
 #[cfg(test)]
 mod integration_tests_j2_j5;
 
-use tracing::Level;
+
 
 /// Initialize the logging subsystem with optional file output.
 ///
 /// Sets up `tracing-subscriber` with console output (colorized) and optionally
 /// writes to a log file. The log level controls verbosity (DEBUG/INFO/WARN/ERROR).
-pub fn init_logging(level: Level, log_file: Option<&str>) {
-    log::init_logging(level, log_file);
+pub fn init_logging(
+    log_level: &str,
+    console_log_level: &str,
+    log_file: Option<&str>,
+    log_backup_count: usize,
+) {
+    log::init_logging(log_level, console_log_level, log_file, log_backup_count);
 }

--- a/aria2-core/src/log.rs
+++ b/aria2-core/src/log.rs
@@ -33,8 +33,12 @@ pub fn init_logging(
     if enable_file_logging {
         let path = log_file.unwrap();
         let p = std::path::Path::new(path);
-        let dir = p.parent().map(|d| d.to_string_lossy().to_string()).unwrap_or_else(|| ".".to_string());
-        let stem = p.file_name()
+        let dir = p
+            .parent()
+            .map(|d| d.to_string_lossy().to_string())
+            .unwrap_or_else(|| ".".to_string());
+        let stem = p
+            .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "aria2.log".to_string());
 
@@ -45,9 +49,7 @@ pub fn init_logging(
             .filename_prefix(&stem)
             .max_log_files(log_backup_count)
             .build(&dir)
-            .unwrap_or_else(|_| {
-                tracing_appender::rolling::daily(&dir, &stem)
-            });
+            .unwrap_or_else(|_| tracing_appender::rolling::daily(&dir, &stem));
         let (non_blocking, guard) = non_blocking(file_appender);
         let _ = LOG_GUARD.set(vec![guard]);
 
@@ -84,9 +86,11 @@ pub fn init_logging(
 
         let _ = tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt::layer()
-                .with_span_events(FmtSpan::CLOSE)
-                .with_target(false))
+            .with(
+                fmt::layer()
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_target(false),
+            )
             .try_init();
     }
 

--- a/aria2-core/src/log.rs
+++ b/aria2-core/src/log.rs
@@ -1,35 +1,93 @@
+use std::sync::OnceLock;
 use tracing::Level;
 use tracing_subscriber::{
     EnvFilter,
     fmt::{self, format::FmtSpan},
-    layer::SubscriberExt,
+    layer::{Layer, SubscriberExt},
     util::SubscriberInitExt,
 };
 
-pub fn init_logging(level: Level, log_file: Option<&str>) {
-    let env_filter = EnvFilter::from_default_env()
-        .add_directive(level.into())
-        .add_directive("hyper=warn".parse().unwrap())
-        .add_directive("reqwest=warn".parse().unwrap());
+static LOG_GUARD: OnceLock<Vec<tracing_appender::non_blocking::WorkerGuard>> = OnceLock::new();
 
-    let fmt_layer = fmt::layer()
-        .with_span_events(FmtSpan::CLOSE)
-        .with_target(false);
+fn parse_log_level(level_str: &str) -> Level {
+    match level_str.to_lowercase().as_str() {
+        "debug" => Level::DEBUG,
+        "info" | "notice" => Level::INFO,
+        "warn" => Level::WARN,
+        "error" => Level::ERROR,
+        _ => Level::INFO,
+    }
+}
 
-    if let Some(_file) = log_file {
+pub fn init_logging(
+    log_level: &str,
+    console_log_level: &str,
+    log_file: Option<&str>,
+    log_backup_count: usize,
+) {
+    let file_level = parse_log_level(log_level);
+    let console_level = parse_log_level(console_log_level);
+
+    let enable_file_logging = log_file.is_some_and(|f| f != "-");
+
+    if enable_file_logging {
+        let path = log_file.unwrap();
+        let p = std::path::Path::new(path);
+        let dir = p.parent().map(|d| d.to_string_lossy().to_string()).unwrap_or_else(|| ".".to_string());
+        let stem = p.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "aria2.log".to_string());
+
         use tracing_appender::non_blocking;
-        let file_appender = tracing_appender::rolling::daily(".", "aria2.log");
-        let (non_blocking, _guard) = non_blocking(file_appender);
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(fmt_layer)
-            .with(fmt::Layer::new().with_writer(non_blocking))
-            .init();
+        use tracing_appender::rolling::Rotation;
+        let file_appender = tracing_appender::rolling::Builder::new()
+            .rotation(Rotation::DAILY)
+            .filename_prefix(&stem)
+            .max_log_files(log_backup_count)
+            .build(&dir)
+            .unwrap_or_else(|_| {
+                tracing_appender::rolling::daily(&dir, &stem)
+            });
+        let (non_blocking, guard) = non_blocking(file_appender);
+        let _ = LOG_GUARD.set(vec![guard]);
+
+        let file_filter = EnvFilter::from_default_env()
+            .add_directive(file_level.into())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("reqwest=warn".parse().unwrap());
+
+        let console_filter = EnvFilter::from_default_env()
+            .add_directive(console_level.into())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("reqwest=warn".parse().unwrap());
+
+        let console_layer = fmt::layer()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(false)
+            .with_filter(console_filter);
+
+        let file_layer = fmt::Layer::new()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(false)
+            .with_writer(non_blocking)
+            .with_filter(file_filter);
+
+        let _ = tracing_subscriber::registry()
+            .with(console_layer)
+            .with(file_layer)
+            .try_init();
     } else {
-        tracing_subscriber::registry()
+        let env_filter = EnvFilter::from_default_env()
+            .add_directive(console_level.into())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("reqwest=warn".parse().unwrap());
+
+        let _ = tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt_layer)
-            .init();
+            .with(fmt::layer()
+                .with_span_events(FmtSpan::CLOSE)
+                .with_target(false))
+            .try_init();
     }
 
     tracing::info!("Log system initialization complete");

--- a/aria2-core/tests/deep_e2e_cross_protocol.rs
+++ b/aria2-core/tests/deep_e2e_cross_protocol.rs
@@ -14,7 +14,7 @@ use aria2_core::filesystem::disk_writer::{ByteArrayDiskWriter, DefaultDiskWriter
 use aria2_core::rate_limiter::{RateLimiter, RateLimiterConfig, ThrottledWriter};
 use aria2_core::request::request_group::{DownloadOptions, GroupId};
 use aria2_core::session::session_entry::SessionEntry;
-use e2e_helpers::mock_http_server::MockHttpServer;
+use e2e_helpers::mock_http_server::{MockHttpServer, Response, StatusCode, full_body};
 use fixtures::mock_ftp_server::{MockFtpServer, small_content};
 use fixtures::test_metalink_builder::{build_metalink_v3, compute_sha256};
 use std::collections::HashMap;
@@ -160,9 +160,9 @@ async fn metalink_mirror_failover() {
     // Primary URL returns 503 Service Unavailable
     let primary_url = format!("{}/error/503-primary", server.base_url());
     server.on_get("/error/503-primary", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-            .body(hyper::Body::from("Service Unavailable"))
+        Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .body(full_body("Service Unavailable"))
             .unwrap()
     });
 

--- a/aria2-core/tests/deep_e2e_http.rs
+++ b/aria2-core/tests/deep_e2e_http.rs
@@ -13,7 +13,7 @@ mod e2e_helpers;
 use crate::e2e_helpers::mock_http_server::MockHttpServer;
 use crate::e2e_helpers::mock_http_server::RequestLog;
 use base64::Engine;
-use hyper::{Body, Request, Response};
+use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, StatusCode, empty_body, full_body};
 
 // ---------------------------------------------------------------------------
 // Inline helpers (from test_harness -- not importable as crate module in integration tests)
@@ -295,30 +295,30 @@ async fn test_http_redirect_301_302_with_cookies() {
 
     // Step 0: initial path returns 301 -> hop_a
     let hop_a = format!("{}/hop_a", base);
-    server.on_get("/start", move |_req: &Request<Body>| -> Response<Body> {
+    server.on_get("/start", move |_req: &Request<Incoming>| -> Response<Body> {
         Response::builder()
             .status(301)
             .header("Location", hop_a.as_str())
-            .body(Body::empty())
+            .body(empty_body())
             .unwrap()
     });
 
     // Step 1: hop_a returns 302 -> hop_b (final destination)
     let hop_b = format!("{}/hop_b", base);
-    server.on_get("/hop_a", move |_req: &Request<Body>| -> Response<Body> {
+    server.on_get("/hop_a", move |_req: &Request<Incoming>| -> Response<Body> {
         Response::builder()
             .status(302)
             .header("Location", hop_b.as_str())
-            .body(Body::empty())
+            .body(empty_body())
             .unwrap()
     });
 
     // Final destination: returns actual content
-    server.on_get("/hop_b", |_req: &Request<Body>| -> Response<Body> {
+    server.on_get("/hop_b", |_req: &Request<Incoming>| -> Response<Body> {
         Response::builder()
             .status(200)
             .header("Content-Length", 13)
-            .body(Body::from(b"final_content".as_slice()))
+            .body(full_body(b"final_content".as_slice()))
             .unwrap()
     });
 
@@ -399,11 +399,11 @@ async fn test_http_redirect_post_to_get() {
     server.on(
         "POST",
         "/submit-form",
-        move |_req: &Request<Body>| -> Response<Body> {
+        move |_req: &Request<Incoming>| -> Response<Body> {
             Response::builder()
-                .status(hyper::StatusCode::MOVED_PERMANENTLY)
+                .status(StatusCode::MOVED_PERMANENTLY)
                 .header("Location", target_clone.as_str())
-                .body(Body::empty())
+                .body(empty_body())
                 .unwrap()
         },
     );
@@ -411,10 +411,10 @@ async fn test_http_redirect_post_to_get() {
     // Register the redirect destination
     server.on_get(
         "/post-destination",
-        |_req: &Request<Body>| -> Response<Body> {
+        |_req: &Request<Incoming>| -> Response<Body> {
             Response::builder()
                 .status(200)
-                .body(Body::from("post_redirect_ok"))
+                .body(full_body("post_redirect_ok"))
                 .unwrap()
         },
     );
@@ -576,11 +576,11 @@ async fn test_http_range_not_supported_fallback() {
 
     // 2. Register a plain endpoint (NO range support)
     let plain_body = b"this_is_plain_content_no_ranges".as_slice();
-    server.on_get("/plain", move |_req: &Request<Body>| -> Response<Body> {
+    server.on_get("/plain", move |_req: &Request<Incoming>| -> Response<Body> {
         Response::builder()
             .status(200)
             .header("Content-Length", plain_body.len())
-            .body(Body::from(plain_body.to_vec()))
+            .body(full_body(plain_body.to_vec()))
             .unwrap()
     });
 
@@ -651,7 +651,7 @@ async fn test_http_slow_server_timeout() {
     let result = client.get(&url).send().await;
     let elapsed_ms = start.elapsed().as_millis();
 
-    // 5. Request behavior depends on Body::wrap_stream():
+    // 5. Request behavior depends on StreamBody (hyper 1.x equivalent of Body::wrap_stream):
     //    - Response headers (200 OK) are sent immediately
     //    - Body data is delayed by 5000ms in the async stream
     //    - reqwest .send() may return Ok(resp) quickly (headers received)
@@ -673,10 +673,14 @@ async fn test_http_slow_server_timeout() {
                     assert_eq!(body_text, "slow_data");
                 }
                 Err(e) => {
-                    // Expected path: timeout while reading the streamed body
+                    // Expected path: timeout while reading the streamed body.
+                    // reqwest 0.13 wraps the timeout in a "decoding response
+                    // body" error, so use `is_timeout()` (which checks the
+                    // full error chain) rather than fragile string matching.
                     let err_str = e.to_string().to_lowercase();
                     assert!(
-                        err_str.contains("timeout")
+                        e.is_timeout()
+                            || err_str.contains("timeout")
                             || err_str.contains("timed out")
                             || err_str.contains("deadline"),
                         "Body read error should be timeout-related, got: {}",
@@ -729,10 +733,10 @@ async fn test_http_timeout_then_retry_success() {
 
     // 2. Register both slow and fast endpoints
     server.register_slow_response("/slow-endpoint", 5000, b"slow_payload");
-    server.on_get("/fast-endpoint", |_req: &Request<Body>| -> Response<Body> {
+    server.on_get("/fast-endpoint", |_req: &Request<Incoming>| -> Response<Body> {
         Response::builder()
             .status(200)
-            .body(Body::from("fast_payload"))
+            .body(full_body("fast_payload"))
             .unwrap()
     });
 
@@ -745,7 +749,7 @@ async fn test_http_timeout_then_retry_success() {
     let base = server.base_url();
 
     // 4. First call: to slow endpoint -> body read should timeout
-    // With Body::wrap_stream(), headers arrive immediately but body is delayed 5000ms
+    // With StreamBody, headers arrive immediately but body is delayed 5000ms
     let slow_url = make_url(&base, "/slow-endpoint");
     let first_result = client.get(&slow_url).send().await;
 

--- a/aria2-core/tests/deep_e2e_http.rs
+++ b/aria2-core/tests/deep_e2e_http.rs
@@ -12,8 +12,10 @@ mod e2e_helpers;
 
 use crate::e2e_helpers::mock_http_server::MockHttpServer;
 use crate::e2e_helpers::mock_http_server::RequestLog;
+use crate::e2e_helpers::mock_http_server::{
+    Body, Incoming, Request, Response, StatusCode, empty_body, full_body,
+};
 use base64::Engine;
-use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, StatusCode, empty_body, full_body};
 
 // ---------------------------------------------------------------------------
 // Inline helpers (from test_harness -- not importable as crate module in integration tests)
@@ -295,23 +297,29 @@ async fn test_http_redirect_301_302_with_cookies() {
 
     // Step 0: initial path returns 301 -> hop_a
     let hop_a = format!("{}/hop_a", base);
-    server.on_get("/start", move |_req: &Request<Incoming>| -> Response<Body> {
-        Response::builder()
-            .status(301)
-            .header("Location", hop_a.as_str())
-            .body(empty_body())
-            .unwrap()
-    });
+    server.on_get(
+        "/start",
+        move |_req: &Request<Incoming>| -> Response<Body> {
+            Response::builder()
+                .status(301)
+                .header("Location", hop_a.as_str())
+                .body(empty_body())
+                .unwrap()
+        },
+    );
 
     // Step 1: hop_a returns 302 -> hop_b (final destination)
     let hop_b = format!("{}/hop_b", base);
-    server.on_get("/hop_a", move |_req: &Request<Incoming>| -> Response<Body> {
-        Response::builder()
-            .status(302)
-            .header("Location", hop_b.as_str())
-            .body(empty_body())
-            .unwrap()
-    });
+    server.on_get(
+        "/hop_a",
+        move |_req: &Request<Incoming>| -> Response<Body> {
+            Response::builder()
+                .status(302)
+                .header("Location", hop_b.as_str())
+                .body(empty_body())
+                .unwrap()
+        },
+    );
 
     // Final destination: returns actual content
     server.on_get("/hop_b", |_req: &Request<Incoming>| -> Response<Body> {
@@ -576,13 +584,16 @@ async fn test_http_range_not_supported_fallback() {
 
     // 2. Register a plain endpoint (NO range support)
     let plain_body = b"this_is_plain_content_no_ranges".as_slice();
-    server.on_get("/plain", move |_req: &Request<Incoming>| -> Response<Body> {
-        Response::builder()
-            .status(200)
-            .header("Content-Length", plain_body.len())
-            .body(full_body(plain_body.to_vec()))
-            .unwrap()
-    });
+    server.on_get(
+        "/plain",
+        move |_req: &Request<Incoming>| -> Response<Body> {
+            Response::builder()
+                .status(200)
+                .header("Content-Length", plain_body.len())
+                .body(full_body(plain_body.to_vec()))
+                .unwrap()
+        },
+    );
 
     // 3. Build client
     let client = reqwest::Client::new();
@@ -733,12 +744,15 @@ async fn test_http_timeout_then_retry_success() {
 
     // 2. Register both slow and fast endpoints
     server.register_slow_response("/slow-endpoint", 5000, b"slow_payload");
-    server.on_get("/fast-endpoint", |_req: &Request<Incoming>| -> Response<Body> {
-        Response::builder()
-            .status(200)
-            .body(full_body("fast_payload"))
-            .unwrap()
-    });
+    server.on_get(
+        "/fast-endpoint",
+        |_req: &Request<Incoming>| -> Response<Body> {
+            Response::builder()
+                .status(200)
+                .body(full_body("fast_payload"))
+                .unwrap()
+        },
+    );
 
     // 3. Build client with short timeout
     let client = reqwest::Client::builder()

--- a/aria2-core/tests/e2e_auth_integration.rs
+++ b/aria2-core/tests/e2e_auth_integration.rs
@@ -8,9 +8,9 @@ mod e2e_helpers;
 mod tests {
     use crate::e2e_helpers::mock_http_server::MockHttpServer;
     use crate::e2e_helpers::mock_http_server::RequestLog;
+    use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, full_body};
     use aria2_core::auth::digest_auth::DigestAlgorithm;
     use aria2_core::auth::*;
-    use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, full_body};
 
     #[tokio::test]
     async fn test_basic_auth_401_then_200() {

--- a/aria2-core/tests/e2e_auth_integration.rs
+++ b/aria2-core/tests/e2e_auth_integration.rs
@@ -10,7 +10,7 @@ mod tests {
     use crate::e2e_helpers::mock_http_server::RequestLog;
     use aria2_core::auth::digest_auth::DigestAlgorithm;
     use aria2_core::auth::*;
-    use hyper::{Body, Request, Response};
+    use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, full_body};
 
     #[tokio::test]
     async fn test_basic_auth_401_then_200() {
@@ -21,18 +21,18 @@ mod tests {
 
         // 2. Register GET /secret -> 401 (no auth) / 200 (with auth)
         // Single handler that handles both cases
-        server.on_get("/secret", |req: &Request<Body>| -> Response<Body> {
+        server.on_get("/secret", |req: &Request<Incoming>| -> Response<Body> {
             // Check for Authorization header (simplified check)
             if req.headers().get("Authorization").is_some() {
                 Response::builder()
                     .status(200)
-                    .body(Body::from("Secret Content"))
+                    .body(full_body("Secret Content"))
                     .unwrap()
             } else {
                 Response::builder()
                     .status(401)
                     .header("WWW-Authenticate", "Basic realm=\"test\"")
-                    .body(Body::from("Unauthorized"))
+                    .body(full_body("Unauthorized"))
                     .unwrap()
             }
         });
@@ -89,14 +89,14 @@ mod tests {
             .expect("Failed to start server");
 
         // Register Digest auth challenge
-        server.on_get("/protected", |_req: &Request<Body>| -> Response<Body> {
+        server.on_get("/protected", |_req: &Request<Incoming>| -> Response<Body> {
             Response::builder()
                 .status(401)
                 .header(
                     "WWW-Authenticate",
                     r#"Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5"#,
                 )
-                .body(Body::from("Unauthorized"))
+                .body(full_body("Unauthorized"))
                 .unwrap()
         });
 

--- a/aria2-core/tests/e2e_helpers/mock_http_server.rs
+++ b/aria2-core/tests/e2e_helpers/mock_http_server.rs
@@ -3,16 +3,44 @@
 #![allow(dead_code)]
 //! Provides a lightweight HTTP server that can be configured with custom handlers,
 //! supporting auth challenges, gzip responses, chunked encoding, and range requests.
+//!
+//! # hyper 1.x architecture
+//! Uses `tokio::net::TcpListener` + `hyper::server::conn::http1::Builder` (the
+//! hyper 1.x replacement for the removed `hyper::server::Server`). Response
+//! bodies are type-erased via `http_body_util::combinators::BoxBody` so that
+//! handlers can return `Full<Bytes>`, `Empty<Bytes>`, or `StreamBody` uniformly.
 
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server, StatusCode};
+use bytes::Bytes;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Empty, Full, StreamBody};
+use hyper::body::Frame;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
-use tokio::sync::oneshot;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 
-/// Mock HTTP handler type
-type HandlerFn = Arc<dyn Fn(&Request<Body>) -> Response<Body> + Send + Sync>;
+// Re-export the types that test files need to construct mock-server handlers.
+// `pub use` also brings these names into scope for internal use, so no separate
+// `use` statements are needed for Request/Response/StatusCode/Incoming.
+// Test files can then write a single import line:
+//   use e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, StatusCode, empty_body, full_body};
+pub use http::{Request, Response, StatusCode};
+pub use hyper::body::Incoming;
+
+/// Type-erased boxed body used for all mock server responses.
+///
+/// Uses `Infallible` as the error type because all body constructors in this
+/// module (`Full`, `Empty`, `StreamBody`) produce infallible bodies. This avoids
+/// `map_err` boilerplate while keeping type erasure via `BoxBody`.
+pub type Body = BoxBody<Bytes, Infallible>;
+
+/// Mock HTTP handler type. Takes a reference to the incoming request and
+/// returns a boxed response body.
+type HandlerFn = Arc<dyn Fn(&Request<Incoming>) -> Response<Body> + Send + Sync>;
 
 struct RouteEntry {
     method: Option<String>,
@@ -24,7 +52,7 @@ pub struct MockHttpServer {
     addr: SocketAddr,
     routes: Arc<RwLock<Vec<RouteEntry>>>,
     request_log: Arc<RwLock<Vec<RequestLog>>>,
-    shutdown_tx: Option<Arc<oneshot::Sender<()>>>,
+    server_handle: Option<JoinHandle<()>>,
 }
 
 #[derive(Debug, Clone)]
@@ -34,77 +62,130 @@ pub struct RequestLog {
     pub headers: Vec<(String, String)>,
 }
 
+/// Helper: create a boxed body from a byte slice.
+pub fn full_body(data: impl Into<Bytes>) -> Body {
+    Full::new(data.into()).boxed()
+}
+
+/// Helper: create an empty boxed body.
+pub fn empty_body() -> Body {
+    Empty::<Bytes>::new().boxed()
+}
+
+/// Helper: create a streaming body from a byte slice. Unlike `full_body`,
+/// this uses a `StreamBody` whose `size_hint` is `Unknown`, so hyper 1.x
+/// will **not** override a manually-set `Content-Length` header. Use this to
+/// simulate truncated/incomplete responses where the header claims more bytes
+/// than the body actually delivers (the client detects a premature EOF).
+pub fn partial_body(data: impl Into<Bytes>) -> Body {
+    let data = data.into();
+    let stream = futures::stream::once(async move { Ok::<_, Infallible>(Frame::data(data)) });
+    StreamBody::new(stream).boxed()
+}
+
 impl MockHttpServer {
     /// Start a new mock server (auto-binds to random port)
     pub async fn start() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let addr: SocketAddr = "127.0.0.1:0".parse()?;
         let routes: Arc<RwLock<Vec<RouteEntry>>> = Arc::new(RwLock::new(Vec::new()));
         let request_log: Arc<RwLock<Vec<RequestLog>>> = Arc::new(RwLock::new(Vec::new()));
-        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let listener = TcpListener::bind(addr).await?;
+        let actual_addr = listener.local_addr()?;
 
         let routes_clone = Arc::clone(&routes);
         let log_clone = Arc::clone(&request_log);
 
-        let make_svc = make_service_fn(move |_conn| {
-            let routes = Arc::clone(&routes_clone);
-            let log = Arc::clone(&log_clone);
-            async move {
-                Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
-                    let routes = Arc::clone(&routes);
-                    let log = Arc::clone(&log);
-                    async move {
-                        // Log the request
-                        let req_log = RequestLog {
-                            method: req.method().to_string(),
-                            path: req.uri().path().to_string(),
-                            headers: req
-                                .headers()
-                                .iter()
-                                .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-                                .collect(),
-                        };
-                        log.write().unwrap().push(req_log);
-
-                        // Find matching route
-                        let routes_guard = routes.read().unwrap();
-                        let method = req.method().to_string();
-                        let path = req.uri().path();
-
-                        for route in routes_guard.iter() {
-                            // Check method match
-                            if let Some(ref m) = route.method
-                                && m != &method
-                            {
-                                continue;
-                            }
-
-                            // Check path match (prefix or exact)
-                            if path.starts_with(&route.path_pattern) || route.path_pattern == path {
-                                let handler = &route.handler;
-                                return Ok::<Response<Body>, Infallible>(handler(&req));
-                            }
-                        }
-
-                        // No matching route found - return 404
-                        Ok(Response::builder()
-                            .status(StatusCode::NOT_FOUND)
-                            .body(Body::from("Not Found"))
-                            .unwrap())
+        let server_handle = tokio::spawn(async move {
+            loop {
+                // Accept connections until the listener is dropped (shutdown).
+                let (stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        eprintln!("Mock HTTP server accept error: {}", e);
+                        break;
                     }
-                }))
-            }
-        });
+                };
 
-        let server = Server::bind(&addr).serve(make_svc);
-        let actual_addr = server.local_addr();
-        let server_with_shutdown = server.with_graceful_shutdown(async {
-            let _ = shutdown_rx.await;
-        });
+                let routes = Arc::clone(&routes_clone);
+                let log = Arc::clone(&log_clone);
+                let io = TokioIo::new(stream);
 
-        // Spawn server in background
-        tokio::spawn(async move {
-            if let Err(e) = server_with_shutdown.await {
-                eprintln!("Mock HTTP server error: {}", e);
+                tokio::spawn(async move {
+                    let svc = service_fn(move |req: Request<Incoming>| {
+                        let routes = Arc::clone(&routes);
+                        let log = Arc::clone(&log);
+                        async move {
+                            // Log the request
+                            let req_log = RequestLog {
+                                method: req.method().to_string(),
+                                path: req.uri().path().to_string(),
+                                headers: req
+                                    .headers()
+                                    .iter()
+                                    .map(|(k, v)| {
+                                        (k.to_string(), v.to_str().unwrap_or("").to_string())
+                                    })
+                                    .collect(),
+                            };
+                            log.write().unwrap().push(req_log);
+
+                            // Find matching route
+                            let routes_guard = routes.read().unwrap();
+                            let method = req.method().to_string();
+                            let path = req.uri().path();
+                            let is_head = method == "HEAD";
+
+                            // First pass: exact method match
+                            for route in routes_guard.iter() {
+                                if let Some(ref m) = route.method
+                                    && m != &method
+                                {
+                                    continue;
+                                }
+                                if path.starts_with(&route.path_pattern)
+                                    || route.path_pattern == path
+                                {
+                                    let handler = &route.handler;
+                                    return Ok::<Response<Body>, Infallible>(handler(&req));
+                                }
+                            }
+
+                            // Second pass (HEAD only): fall back to GET handler.
+                            // Construct a HEAD response: copy status and all headers
+                            // from the GET response, but with an empty body.
+                            if is_head {
+                                for route in routes_guard.iter() {
+                                    if let Some(ref m) = route.method
+                                        && m != "GET"
+                                    {
+                                        continue;
+                                    }
+                                    if path.starts_with(&route.path_pattern)
+                                        || route.path_pattern == path
+                                    {
+                                        let handler = &route.handler;
+                                        let resp = handler(&req);
+                                        let status = resp.status();
+                                        let headers = resp.headers().clone();
+                                        let mut head_resp = Response::new(empty_body());
+                                        *head_resp.status_mut() = status;
+                                        head_resp.headers_mut().extend(headers);
+                                        return Ok::<Response<Body>, Infallible>(head_resp);
+                                    }
+                                }
+                            }
+
+                            // No matching route found - return 404
+                            Ok(Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body(full_body("Not Found"))
+                                .unwrap())
+                        }
+                    });
+
+                    let _ = http1::Builder::new().serve_connection(io, svc).await;
+                });
             }
         });
 
@@ -112,14 +193,14 @@ impl MockHttpServer {
             addr: actual_addr,
             routes,
             request_log,
-            shutdown_tx: Some(Arc::new(shutdown_tx)),
+            server_handle: Some(server_handle),
         })
     }
 
     /// Register GET route handler
     pub fn on_get<F>(&self, pattern: &str, handler: F)
     where
-        F: Fn(&Request<Body>) -> Response<Body> + Send + Sync + 'static,
+        F: Fn(&Request<Incoming>) -> Response<Body> + Send + Sync + 'static,
     {
         self.on("GET", pattern, handler)
     }
@@ -127,7 +208,7 @@ impl MockHttpServer {
     /// Register arbitrary method route
     pub fn on<F>(&self, method: &str, pattern: &str, handler: F)
     where
-        F: Fn(&Request<Body>) -> Response<Body> + Send + Sync + 'static,
+        F: Fn(&Request<Incoming>) -> Response<Body> + Send + Sync + 'static,
     {
         let entry = RouteEntry {
             method: Some(method.to_string()),
@@ -141,14 +222,14 @@ impl MockHttpServer {
     pub fn register_auth_challenge(&self, realm: &str, auth_type: &str) {
         let realm = realm.to_string();
         let auth_type = auth_type.to_string();
-        self.on_get("/secret", move |_req: &Request<Body>| -> Response<Body> {
+        self.on_get("/secret", move |_req: &Request<Incoming>| -> Response<Body> {
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header(
                     "WWW-Authenticate",
                     format!("{} realm=\"{}\"", auth_type, realm),
                 )
-                .body(Body::from("Unauthorized"))
+                .body(full_body("Unauthorized"))
                 .unwrap()
         });
     }
@@ -166,12 +247,12 @@ impl MockHttpServer {
         let path = path.to_string();
         self.on_get(
             path.as_str(),
-            move |_req: &Request<Body>| -> Response<Body> {
+            move |_req: &Request<Incoming>| -> Response<Body> {
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("Content-Encoding", "gzip")
                     .header("Content-Type", "application/octet-stream")
-                    .body(Body::from(compressed.clone()))
+                    .body(full_body(compressed.clone()))
                     .unwrap()
             },
         );
@@ -182,7 +263,7 @@ impl MockHttpServer {
         let path = path.to_string();
         self.on_get(
             path.as_str(),
-            move |_req: &Request<Body>| -> Response<Body> {
+            move |_req: &Request<Incoming>| -> Response<Body> {
                 // Return plain data; hyper handles chunked encoding when
                 // Transfer-Encoding header is set
                 let body: Vec<u8> = chunks.iter().flatten().copied().collect();
@@ -190,7 +271,7 @@ impl MockHttpServer {
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("Transfer-Encoding", "chunked")
-                    .body(Body::from(body))
+                    .body(full_body(body))
                     .unwrap()
             },
         );
@@ -202,14 +283,14 @@ impl MockHttpServer {
         let path = path.to_string();
         self.on_get(
             path.as_str(),
-            move |req: &Request<Body>| -> Response<Body> {
+            move |req: &Request<Incoming>| -> Response<Body> {
                 // Handle empty body case
                 if body.is_empty() {
                     return Response::builder()
                         .status(StatusCode::OK)
                         .header("Accept-Ranges", "bytes")
                         .header("Content-Length", 0)
-                        .body(Body::empty())
+                        .body(empty_body())
                         .unwrap();
                 }
 
@@ -222,7 +303,6 @@ impl MockHttpServer {
                         && let Some((start_str, end_str)) = range_part.split_once('-')
                     {
                         let start: u64 = start_str.parse().unwrap_or(0);
-                        // Handle empty end_str (means "to end of file")
                         let end: u64 = if end_str.is_empty() {
                             body.len() as u64 - 1
                         } else {
@@ -235,7 +315,7 @@ impl MockHttpServer {
                             return Response::builder()
                                 .status(StatusCode::RANGE_NOT_SATISFIABLE)
                                 .header("Content-Range", format!("bytes=*/{}", body.len()))
-                                .body(Body::empty())
+                                .body(empty_body())
                                 .unwrap();
                         }
 
@@ -247,7 +327,7 @@ impl MockHttpServer {
                                 format!("bytes={}-{}/{}", start, end, body.len()),
                             )
                             .header("Accept-Ranges", "bytes")
-                            .body(Body::from(slice.to_vec()))
+                            .body(full_body(slice.to_vec()))
                             .unwrap();
                     }
                 }
@@ -257,7 +337,7 @@ impl MockHttpServer {
                     .status(StatusCode::OK)
                     .header("Accept-Ranges", "bytes")
                     .header("Content-Length", body.len())
-                    .body(Body::from(body.clone()))
+                    .body(full_body(body.clone()))
                     .unwrap()
             },
         );
@@ -274,19 +354,19 @@ impl MockHttpServer {
         let body = body.to_vec();
         self.on_get(
             path.as_str(),
-            move |_req: &Request<Body>| -> Response<Body> {
-                // Use async streaming Body to delay without blocking the tokio runtime.
-                // hyper::Body::wrap_stream() accepts any impl Stream<Item = Result<Bytes, E>>.
+            move |_req: &Request<Incoming>| -> Response<Body> {
+                // Use async streaming body to delay without blocking the tokio runtime.
+                // hyper 1.x `StreamBody` expects `Stream<Item = Result<Frame<D>, E>>`.
                 use futures::stream;
                 let body_clone = body.clone();
                 let stream = stream::once(async move {
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                    Ok::<_, std::convert::Infallible>(bytes::Bytes::from(body_clone))
+                    Ok::<_, Infallible>(Frame::data(Bytes::from(body_clone)))
                 });
                 Response::builder()
                     .status(StatusCode::OK)
                     .header("Content-Length", body.len())
-                    .body(Body::wrap_stream(stream))
+                    .body(StreamBody::new(stream).boxed())
                     .unwrap()
             },
         );
@@ -306,7 +386,7 @@ impl MockHttpServer {
             self.on_get(path, move |_| {
                 Response::builder()
                     .status(StatusCode::OK)
-                    .body(Body::from(final_body.clone()))
+                    .body(full_body(final_body.clone()))
                     .unwrap()
             });
             return;
@@ -342,7 +422,7 @@ impl MockHttpServer {
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Content-Length", fb.len())
-                        .body(Body::from(fb.clone()))
+                        .body(full_body(fb.clone()))
                         .unwrap()
                 });
             } else {
@@ -354,7 +434,7 @@ impl MockHttpServer {
                         .status(status)
                         .header("Location", loc.as_str())
                         .header("Content-Length", "0")
-                        .body(Body::empty())
+                        .body(empty_body())
                         .unwrap()
                 });
             }
@@ -376,7 +456,7 @@ impl MockHttpServer {
 
         self.on_get(
             path.as_str(),
-            move |req: &Request<Body>| -> Response<Body> {
+            move |req: &Request<Incoming>| -> Response<Body> {
                 // Validate Authorization header: must be present, non-empty,
                 // AND start with the expected scheme prefix (e.g., "Basic " or "Digest ")
                 let expected_prefix = format!("{} ", auth_type);
@@ -391,7 +471,7 @@ impl MockHttpServer {
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Content-Length", body.len())
-                        .body(Body::from(body.clone()))
+                        .body(full_body(body.clone()))
                         .unwrap()
                 } else {
                     Response::builder()
@@ -400,7 +480,7 @@ impl MockHttpServer {
                             "WWW-Authenticate",
                             format!("{} realm=\"{}\"", auth_type, realm),
                         )
-                        .body(Body::from("Unauthorized"))
+                        .body(full_body("Unauthorized"))
                         .unwrap()
                 }
             },
@@ -411,21 +491,21 @@ impl MockHttpServer {
     ///
     /// # Arguments
     /// * `path` - URL path
-    /// * `full_body` - Full intended body (used for Content-Length header)
+    /// * `full_body_bytes` - Full intended body (used for Content-Length header)
     /// * `serve_bytes` - Number of bytes to actually send before truncating
-    pub fn register_partial_serve(&self, path: &str, full_body: &[u8], serve_bytes: usize) {
-        let full_body = full_body.to_vec();
-        let partial = full_body[..serve_bytes.min(full_body.len())].to_vec();
+    pub fn register_partial_serve(&self, path: &str, full_body_bytes: &[u8], serve_bytes: usize) {
+        let full_body_bytes = full_body_bytes.to_vec();
+        let partial = full_body_bytes[..serve_bytes.min(full_body_bytes.len())].to_vec();
         let path = path.to_string();
 
         self.on_get(
             path.as_str(),
-            move |_req: &Request<Body>| -> Response<Body> {
+            move |_req: &Request<Incoming>| -> Response<Body> {
                 // Claim full size but deliver truncated data (simulates connection drop)
                 Response::builder()
                     .status(StatusCode::OK)
-                    .header("Content-Length", full_body.len())
-                    .body(Body::from(partial.clone()))
+                    .header("Content-Length", full_body_bytes.len())
+                    .body(full_body(partial.clone()))
                     .unwrap()
             },
         );
@@ -445,7 +525,7 @@ impl MockHttpServer {
 
         self.on_get(
             path.as_str(),
-            move |req: &Request<Body>| -> Response<Body> {
+            move |req: &Request<Incoming>| -> Response<Body> {
                 let count = request_count.fetch_add(1, Ordering::SeqCst);
 
                 if count == 0 {
@@ -453,7 +533,7 @@ impl MockHttpServer {
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Set-Cookie", "session=test_abc123; Path=/")
-                        .body(Body::from("cookie_set"))
+                        .body(full_body("cookie_set"))
                         .unwrap()
                 } else {
                     // Subsequent visits: verify cookie is echoed back
@@ -468,12 +548,12 @@ impl MockHttpServer {
                         seen_cookies.write().unwrap().insert(cookie_header);
                         Response::builder()
                             .status(StatusCode::OK)
-                            .body(Body::from("cookie_verified"))
+                            .body(full_body("cookie_verified"))
                             .unwrap()
                     } else {
                         Response::builder()
                             .status(StatusCode::BAD_REQUEST)
-                            .body(Body::from("missing_cookie"))
+                            .body(full_body("missing_cookie"))
                             .unwrap()
                     }
                 }
@@ -496,13 +576,11 @@ impl MockHttpServer {
     }
 
     /// Shutdown server gracefully
-    pub async fn shutdown(self) {
-        if let Some(tx) = self.shutdown_tx
-            && let Ok(sender) = Arc::try_unwrap(tx)
-        {
-            let _ = sender.send(());
+    pub async fn shutdown(mut self) {
+        if let Some(handle) = self.server_handle.take() {
+            handle.abort();
         }
-        // Give time for graceful shutdown
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        // Give time for in-flight connections to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await
     }
 }

--- a/aria2-core/tests/e2e_helpers/mock_http_server.rs
+++ b/aria2-core/tests/e2e_helpers/mock_http_server.rs
@@ -222,16 +222,19 @@ impl MockHttpServer {
     pub fn register_auth_challenge(&self, realm: &str, auth_type: &str) {
         let realm = realm.to_string();
         let auth_type = auth_type.to_string();
-        self.on_get("/secret", move |_req: &Request<Incoming>| -> Response<Body> {
-            Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .header(
-                    "WWW-Authenticate",
-                    format!("{} realm=\"{}\"", auth_type, realm),
-                )
-                .body(full_body("Unauthorized"))
-                .unwrap()
-        });
+        self.on_get(
+            "/secret",
+            move |_req: &Request<Incoming>| -> Response<Body> {
+                Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .header(
+                        "WWW-Authenticate",
+                        format!("{} realm=\"{}\"", auth_type, realm),
+                    )
+                    .body(full_body("Unauthorized"))
+                    .unwrap()
+            },
+        );
     }
 
     /// Quick method: return gzip compressed response

--- a/aria2-core/tests/e2e_stream_filter_integration.rs
+++ b/aria2-core/tests/e2e_stream_filter_integration.rs
@@ -8,8 +8,8 @@ mod e2e_helpers;
 mod tests {
     use crate::e2e_helpers::mock_http_server::MockHttpServer;
     use crate::e2e_helpers::mock_http_server::RequestLog;
-    use aria2_core::http::stream_filter::*;
     use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, full_body};
+    use aria2_core::http::stream_filter::*;
 
     #[tokio::test]
     async fn test_gzip_download_full_roundtrip() {
@@ -154,13 +154,16 @@ mod tests {
         let data_vec: Vec<u8> = original_data.to_vec();
 
         // Register plain response (no Content-Encoding)
-        server.on_get("/plain", move |_req: &Request<Incoming>| -> Response<Body> {
-            Response::builder()
-                .status(200)
-                .header("Content-Type", "text/plain")
-                .body(full_body(data_vec.clone()))
-                .unwrap()
-        });
+        server.on_get(
+            "/plain",
+            move |_req: &Request<Incoming>| -> Response<Body> {
+                Response::builder()
+                    .status(200)
+                    .header("Content-Type", "text/plain")
+                    .body(full_body(data_vec.clone()))
+                    .unwrap()
+            },
+        );
 
         // Fetch the data
         let client = reqwest::Client::new();

--- a/aria2-core/tests/e2e_stream_filter_integration.rs
+++ b/aria2-core/tests/e2e_stream_filter_integration.rs
@@ -9,7 +9,7 @@ mod tests {
     use crate::e2e_helpers::mock_http_server::MockHttpServer;
     use crate::e2e_helpers::mock_http_server::RequestLog;
     use aria2_core::http::stream_filter::*;
-    use hyper::{Body, Request, Response};
+    use crate::e2e_helpers::mock_http_server::{Body, Incoming, Request, Response, full_body};
 
     #[tokio::test]
     async fn test_gzip_download_full_roundtrip() {
@@ -154,11 +154,11 @@ mod tests {
         let data_vec: Vec<u8> = original_data.to_vec();
 
         // Register plain response (no Content-Encoding)
-        server.on_get("/plain", move |_req: &Request<Body>| -> Response<Body> {
+        server.on_get("/plain", move |_req: &Request<Incoming>| -> Response<Body> {
             Response::builder()
                 .status(200)
                 .header("Content-Type", "text/plain")
-                .body(Body::from(data_vec.clone()))
+                .body(full_body(data_vec.clone()))
                 .unwrap()
         });
 

--- a/aria2-core/tests/engine_integration_tests.rs
+++ b/aria2-core/tests/engine_integration_tests.rs
@@ -19,7 +19,7 @@ use aria2_core::rate_limiter::RateLimiterConfig;
 use aria2_core::request::request_group::{DownloadOptions, GroupId};
 
 // Re-export helpers from test harness module
-use e2e_helpers::mock_http_server::MockHttpServer;
+use e2e_helpers::mock_http_server::{MockHttpServer, Response, StatusCode, full_body};
 
 // Import test harness utilities (need to check what's available)
 // Note: These may need adjustment based on actual module structure
@@ -587,9 +587,9 @@ async fn engine_error_cleanup_on_failure() {
 
     // Register route that always returns 404 Not Found
     server.on_get("/nonexistent.bin", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::NOT_FOUND)
-            .body(hyper::Body::from("Not Found"))
+        Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(full_body("Not Found"))
             .unwrap()
     });
 
@@ -626,9 +626,9 @@ async fn engine_error_cleanup_on_failure() {
 
     // Also test 500 error case
     server.on_get("/server_error.bin", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-            .body(hyper::Body::from("Internal Server Error"))
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(full_body("Internal Server Error"))
             .unwrap()
     });
 

--- a/aria2-core/tests/test_e2e_concurrent_http_range.rs
+++ b/aria2-core/tests/test_e2e_concurrent_http_range.rs
@@ -1,0 +1,245 @@
+//! E2E tests: DownloadCommand concurrent path (FuturesUnordered) over real HTTP.
+//!
+//! Each test starts a MockHttpServer that serves a file with Range support,
+//! creates a DownloadCommand with split > 1, executes it, and verifies
+//! the assembled output is correct and progress updates are reported.
+//!
+//! These tests fill the gap between:
+//! - `test_e2e_http_concurrent.rs` — only tests constructor + segment manager units
+//! - `test_e2e_download.rs` — only tests the sequential path (split = 1)
+
+mod e2e_helpers;
+
+use aria2_core::engine::command::Command;
+use aria2_core::engine::download_command::DownloadCommand;
+use aria2_core::request::request_group::{DownloadOptions, GroupId};
+
+use crate::e2e_helpers::mock_http_server::MockHttpServer;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Generate deterministic test data (reproducible across runs).
+fn generate_test_data(size: usize, seed: u8) -> Vec<u8> {
+    (0..size).map(|i| (i as u8).wrapping_add(seed)).collect()
+}
+
+/// Build URL from base + path
+fn make_url(base: &str, path: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if path.starts_with('/') {
+        format!("{}{}", trimmed, path)
+    } else {
+        format!("{}/{}", trimmed, path)
+    }
+}
+
+/// Create a minimal DownloadOptions with split and max_connection_per_server.
+fn make_options(
+    split: Option<u16>,
+    max_conn: Option<u16>,
+    dir: &str,
+    out: &str,
+) -> DownloadOptions {
+    DownloadOptions {
+        split,
+        max_connection_per_server: max_conn,
+        max_download_limit: None,
+        max_upload_limit: None,
+        dir: Some(dir.to_string()),
+        out: Some(out.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Check if a request log entry has a Range header.
+fn has_range_header(entry: &crate::e2e_helpers::mock_http_server::RequestLog) -> bool {
+    entry
+        .headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("range"))
+}
+
+/// Register a GET range handler for the given path.
+///
+/// HEAD requests are automatically handled by the mock server's fallback logic:
+/// when no explicit HEAD handler matches, the server matches against GET handlers
+/// and strips the response body. This ensures `Content-Length` and `Accept-Ranges`
+/// headers from the GET handler are returned for HEAD probes, which is required
+/// to trigger the concurrent download path.
+fn register_range_with_head(server: &MockHttpServer, path: &str, body: &[u8]) {
+    server.register_range_response(path, body);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Concurrent download assembles file correctly
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_concurrent_download_assembles_file_correctly() {
+    let server = MockHttpServer::start()
+        .await
+        .expect("Failed to start mock server");
+
+    // 2MB file >= CONCURRENT_MIN_FILE_SIZE (1MB), so concurrent path is used
+    let file_size = 2 * 1024 * 1024;
+    let data = generate_test_data(file_size, 42);
+    register_range_with_head(&server, "/largefile", &data);
+
+    let url = make_url(&server.base_url(), "/largefile");
+    let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
+    let out_name = format!("test_concurrent_asm_{}.bin", std::process::id());
+    let out_path = format!("{}/{}", tmp_dir, &out_name);
+
+    // Clean up any leftover from previous runs
+    let _ = std::fs::remove_file(&out_path);
+
+    let mut cmd = DownloadCommand::new(
+        GroupId::new(1),
+        &url,
+        &make_options(Some(4), Some(2), &tmp_dir, &out_name),
+        Some(&tmp_dir),
+        Some(&out_name),
+    )
+    .expect("Failed to create DownloadCommand");
+
+    cmd.execute()
+        .await
+        .expect("Concurrent download should succeed");
+
+    // Verify: output file exists and has correct size
+    let metadata = std::fs::metadata(&out_path).expect("Output file should exist");
+    assert_eq!(
+        metadata.len() as usize,
+        file_size,
+        "Output file size should match"
+    );
+
+    // Verify: content is byte-for-byte identical
+    let output_data = std::fs::read(&out_path).expect("Should read output file");
+    assert_eq!(output_data, data, "Output content should match source data");
+
+    // Verify: at least 2 Range requests were made (proving concurrent split download)
+    let log = server.take_request_log();
+    let range_count = log.iter().filter(|e| has_range_header(e)).count();
+    assert!(
+        range_count >= 2,
+        "Expected at least 2 Range requests, got {}",
+        range_count
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_file(&out_path);
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Small file (< CONCURRENT_MIN_FILE_SIZE) uses single segment
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_concurrent_download_small_file_sequential() {
+    let server = MockHttpServer::start()
+        .await
+        .expect("Failed to start mock server");
+
+    // 500KB < CONCURRENT_MIN_FILE_SIZE (1MB), so sequential path is used
+    let file_size = 500 * 1024;
+    let data = generate_test_data(file_size, 7);
+    server.register_range_response("/smallfile", &data);
+
+    let url = make_url(&server.base_url(), "/smallfile");
+    let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
+    let out_name = format!("test_concurrent_small_{}.bin", std::process::id());
+    let out_path = format!("{}/{}", tmp_dir, &out_name);
+    let _ = std::fs::remove_file(&out_path);
+
+    let mut cmd = DownloadCommand::new(
+        GroupId::new(3),
+        &url,
+        &make_options(Some(4), Some(2), &tmp_dir, &out_name),
+        Some(&tmp_dir),
+        Some(&out_name),
+    )
+    .expect("Failed to create DownloadCommand");
+
+    cmd.execute()
+        .await
+        .expect("Download should succeed");
+
+    // Verify file
+    let metadata = std::fs::metadata(&out_path).expect("Output file should exist");
+    assert_eq!(
+        metadata.len() as usize,
+        file_size,
+        "Output file size should match"
+    );
+
+    let output_data = std::fs::read(&out_path).expect("Should read output file");
+    assert_eq!(output_data, data, "Output content should match source data");
+
+    // Verify: no Range requests (sequential path doesn't split into byte ranges)
+    let log = server.take_request_log();
+    for entry in &log {
+        assert!(
+            !has_range_header(entry),
+            "Small file should NOT use Range requests (sequential path)"
+        );
+    }
+
+    // Cleanup
+    let _ = std::fs::remove_file(&out_path);
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Multiple Range requests made for large file
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_concurrent_download_multiple_range_requests() {
+    let server = MockHttpServer::start()
+        .await
+        .expect("Failed to start mock server");
+
+    let file_size = 2 * 1024 * 1024;
+    let data = generate_test_data(file_size, 123);
+    register_range_with_head(&server, "/range-test", &data);
+
+    let url = make_url(&server.base_url(), "/range-test");
+    let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
+    let out_name = format!("test_concurrent_range_{}.bin", std::process::id());
+    let out_path = format!("{}/{}", tmp_dir, &out_name);
+    let _ = std::fs::remove_file(&out_path);
+
+    let mut cmd = DownloadCommand::new(
+        GroupId::new(4),
+        &url,
+        &make_options(Some(4), Some(2), &tmp_dir, &out_name),
+        Some(&tmp_dir),
+        Some(&out_name),
+    )
+    .expect("Failed to create DownloadCommand");
+
+    cmd.execute()
+        .await
+        .expect("Concurrent download should succeed");
+
+    // Verify file content
+    let output_data = std::fs::read(&out_path).expect("Should read output file");
+    assert_eq!(output_data, data, "Output content should match source data");
+
+    // Verify: multiple Range requests were made
+    let log = server.take_request_log();
+    let range_entries: Vec<_> = log.iter().filter(|e| has_range_header(e)).collect();
+    assert!(
+        range_entries.len() >= 2,
+        "Expected at least 2 Range requests, got {}",
+        range_entries.len()
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_file(&out_path);
+    server.shutdown().await;
+}

--- a/aria2-core/tests/test_e2e_concurrent_http_range.rs
+++ b/aria2-core/tests/test_e2e_concurrent_http_range.rs
@@ -164,9 +164,7 @@ async fn test_concurrent_download_small_file_sequential() {
     )
     .expect("Failed to create DownloadCommand");
 
-    cmd.execute()
-        .await
-        .expect("Download should succeed");
+    cmd.execute().await.expect("Download should succeed");
 
     // Verify file
     let metadata = std::fs::metadata(&out_path).expect("Output file should exist");

--- a/aria2-core/tests/test_e2e_concurrent_http_range.rs
+++ b/aria2-core/tests/test_e2e_concurrent_http_range.rs
@@ -90,7 +90,7 @@ async fn test_concurrent_download_assembles_file_correctly() {
     let url = make_url(&server.base_url(), "/largefile");
     let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
     let out_name = format!("test_concurrent_asm_{}.bin", std::process::id());
-    let out_path = format!("{}/{}", tmp_dir, &out_name);
+    let out_path = format!("{}/{}", tmp_dir, out_name);
 
     // Clean up any leftover from previous runs
     let _ = std::fs::remove_file(&out_path);
@@ -152,7 +152,7 @@ async fn test_concurrent_download_small_file_sequential() {
     let url = make_url(&server.base_url(), "/smallfile");
     let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
     let out_name = format!("test_concurrent_small_{}.bin", std::process::id());
-    let out_path = format!("{}/{}", tmp_dir, &out_name);
+    let out_path = format!("{}/{}", tmp_dir, out_name);
     let _ = std::fs::remove_file(&out_path);
 
     let mut cmd = DownloadCommand::new(
@@ -179,14 +179,19 @@ async fn test_concurrent_download_small_file_sequential() {
     let output_data = std::fs::read(&out_path).expect("Should read output file");
     assert_eq!(output_data, data, "Output content should match source data");
 
-    // Verify: no Range requests (sequential path doesn't split into byte ranges)
+    // Verify: small file should NOT use concurrent split download.
+    // The sequential path never splits into multiple byte ranges. On Linux the
+    // splice optimization (`try_splice_download`) issues a single full-file
+    // Range request (`bytes=0-N`) for zero-copy transfer — this is still a
+    // single segment, not concurrent splitting, so at most one Range request
+    // is acceptable.
     let log = server.take_request_log();
-    for entry in &log {
-        assert!(
-            !has_range_header(entry),
-            "Small file should NOT use Range requests (sequential path)"
-        );
-    }
+    let range_count = log.iter().filter(|e| has_range_header(e)).count();
+    assert!(
+        range_count <= 1,
+        "Small file should NOT use concurrent split download (Range requests: {})",
+        range_count
+    );
 
     // Cleanup
     let _ = std::fs::remove_file(&out_path);
@@ -210,7 +215,7 @@ async fn test_concurrent_download_multiple_range_requests() {
     let url = make_url(&server.base_url(), "/range-test");
     let tmp_dir = std::env::temp_dir().to_string_lossy().into_owned();
     let out_name = format!("test_concurrent_range_{}.bin", std::process::id());
-    let out_path = format!("{}/{}", tmp_dir, &out_name);
+    let out_path = format!("{}/{}", tmp_dir, out_name);
     let _ = std::fs::remove_file(&out_path);
 
     let mut cmd = DownloadCommand::new(

--- a/aria2-core/tests/test_error_network.rs
+++ b/aria2-core/tests/test_error_network.rs
@@ -16,7 +16,9 @@ use aria2_core::error::{Aria2Error, FatalError, RecoverableError};
 use aria2_core::http::connection::{HttpConfig, HttpConnectionManager};
 use aria2_core::request::request_group::{DownloadOptions, GroupId};
 use aria2_core::retry::{RetryExecutor, RetryPolicy, RetryStats};
-use e2e_helpers::mock_http_server::MockHttpServer;
+use e2e_helpers::mock_http_server::{
+    MockHttpServer, Response, StatusCode, full_body, partial_body,
+};
 use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
@@ -80,12 +82,16 @@ async fn test_connection_reset_error_handling() {
         .await
         .expect("Failed to start mock server");
 
-    // Register a handler that immediately closes after sending headers
+    // Register a handler that sends headers claiming 1MB but only delivers
+    // 100 bytes, then closes the stream. This simulates a connection reset
+    // mid-transfer. Using `partial_body` (StreamBody with Unknown size_hint)
+    // ensures hyper 1.x respects the manually-set Content-Length header, so
+    // the client detects the premature EOF.
     server.on_get("/reset.bin", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::OK)
-            .header("Content-Length", "1000000") // Claim 1MB but don't send body
-            .body(hyper::Body::empty())
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Length", "1000000") // Claim 1MB
+            .body(partial_body(vec![0u8; 100])) // But only send 100 bytes
             .unwrap()
     });
 
@@ -351,9 +357,9 @@ async fn test_http_500_server_error() {
         .expect("Failed to start mock server");
 
     server.on_get("/error500", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-            .body(hyper::Body::from("Internal Server Error"))
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(full_body("Internal Server Error"))
             .unwrap()
     });
 
@@ -415,9 +421,9 @@ async fn test_http_404_no_retry() {
         .expect("Failed to start mock server");
 
     server.on_get("/notfound", |_req| {
-        hyper::Response::builder()
-            .status(hyper::StatusCode::NOT_FOUND)
-            .body(hyper::Body::from("Not Found"))
+        Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(full_body("Not Found"))
             .unwrap()
     });
 

--- a/aria2-protocol/Cargo.toml
+++ b/aria2-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-protocol"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -24,8 +24,10 @@ tracing.workspace = true
 bytes.workspace = true
 async-trait.workspace = true
 
-reqwest = { version = "0.11", features = ["rustls-tls", "gzip", "brotli", "socks"] }
-hyper = { version = "0.14", features = ["full", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "gzip", "brotli", "socks", "http2"] }
+# hyper dependency removed: aria2-protocol does not use hyper directly (verified
+# via `rg "hyper::" aria2-protocol/src/` — zero matches). reqwest 0.13.4 brings
+# in hyper 1.x transitively, so no direct hyper dependency is needed here.
 rustls = "0.21"
 rustls-pemfile = "1.0"
 quick-xml = "0.31"

--- a/aria2-protocol/src/bittorrent/dht/engine.rs
+++ b/aria2-protocol/src/bittorrent/dht/engine.rs
@@ -565,6 +565,12 @@ impl DhtEngine {
         }
     }
 
+    /// Shutdown the DHT engine synchronously.
+    ///
+    /// **Do not call from `async` contexts.** This method uses
+    /// `tokio::sync::RwLock::blocking_read()`, which blocks the tokio worker
+    /// thread and can deadlock if another task holds the routing table's write
+    /// lock. Use [`shutdown_async`](Self::shutdown_async) instead from async code.
     pub fn shutdown(&self) {
         self.running.store(false, Ordering::Relaxed);
 
@@ -960,7 +966,7 @@ mod tests {
             stats.total_nodes >= 4,
             "should have at least bootstrap nodes"
         );
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -979,7 +985,7 @@ mod tests {
             "should complete at least one round"
         );
         let _ = result.nodes_contacted;
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[test]
@@ -1000,7 +1006,7 @@ mod tests {
     async fn test_shutdown_sets_flag() {
         let engine = DhtEngine::start(DhtEngineConfig::default()).await.unwrap();
         assert!(engine.running.load(Ordering::Relaxed));
-        engine.shutdown();
+        engine.shutdown_async().await;
         assert!(!engine.running.load(Ordering::Relaxed));
     }
 
@@ -1009,7 +1015,7 @@ mod tests {
         let engine = DhtEngine::start(DhtEngineConfig::default()).await.unwrap();
         let addr = engine.local_addr();
         assert!(addr.port() > 0, "should have a valid port");
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1021,7 +1027,7 @@ mod tests {
             engine.running.load(Ordering::Relaxed),
             "maintenance should keep engine running"
         );
-        engine.shutdown();
+        engine.shutdown_async().await;
         sleep(Duration::from_millis(200)).await;
     }
 
@@ -1182,7 +1188,7 @@ mod tests {
             stats.total_nodes >= 4,
             "engine should still work after skipped save"
         );
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[test]
@@ -1227,7 +1233,7 @@ mod tests {
             HARDCODED_BOOTSTRAP_NODES.len()
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     // ==================== Task 8: DHT Query Handler Tests ====================
@@ -1269,7 +1275,7 @@ mod tests {
         let received = rx.await.expect("receiver should get the message");
         assert!(received.is_response());
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1280,7 +1286,7 @@ mod tests {
         let found = engine.complete_pending_query(&[0xFF, 0xFF], msg);
         assert!(!found, "complete for unknown tx_id should return false");
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1301,7 +1307,7 @@ mod tests {
         let found = engine.complete_pending_query(&tx_id, msg);
         assert!(!found, "complete after cancel should return false");
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     // ---- Compact node encoder test (Task 5 helper) ----
@@ -1435,7 +1441,7 @@ mod tests {
             "r.id should be engine's self_id"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1475,7 +1481,7 @@ mod tests {
             );
         }
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1514,7 +1520,7 @@ mod tests {
             "should not have values field when no peers"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1547,7 +1553,7 @@ mod tests {
             stored_peers
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1576,7 +1582,7 @@ mod tests {
             "no peer should be stored for invalid token"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1623,7 +1629,7 @@ mod tests {
             "implied_port should use sender's address, not the port field"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1665,7 +1671,7 @@ mod tests {
         let token = r.dict_get(b"token").and_then(|v| v.as_bytes());
         assert!(token.is_some(), "should still include a token");
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1687,7 +1693,7 @@ mod tests {
             "missing fields should result in error response"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     // ---- Full roundtrip tests (Task 8: integration) ----
@@ -1728,8 +1734,8 @@ mod tests {
             "response r.id should be engine B's self_id"
         );
 
-        engine_a.shutdown();
-        engine_b.shutdown();
+        engine_a.shutdown_async().await;
+        engine_b.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1767,8 +1773,8 @@ mod tests {
         let token = r.dict_get(b"token").and_then(|v| v.as_bytes());
         assert!(token.is_some(), "get_peers response should include a token");
 
-        engine_a.shutdown();
-        engine_b.shutdown();
+        engine_a.shutdown_async().await;
+        engine_b.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1849,8 +1855,8 @@ mod tests {
             stored_peers
         );
 
-        engine_a.shutdown();
-        engine_b.shutdown();
+        engine_a.shutdown_async().await;
+        engine_b.shutdown_async().await;
     }
 
     // ---- Shutdown test (Task 8.7) ----
@@ -1917,7 +1923,7 @@ mod tests {
             "should complete 0 rounds (cache hit)"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 
     #[tokio::test]
@@ -1942,6 +1948,6 @@ mod tests {
             "no peers should be stored if none were found"
         );
 
-        engine.shutdown();
+        engine.shutdown_async().await;
     }
 }

--- a/aria2-rpc/Cargo.toml
+++ b/aria2-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-rpc"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aria2-rpc/src/handlers/status.rs
+++ b/aria2-rpc/src/handlers/status.rs
@@ -32,7 +32,9 @@ impl RpcEngine {
                             .with_total_length(total)
                             .with_completed_length(completed)
                             .with_download_speed(g.get_download_speed_cached())
-                            .with_upload_length(g.get_uploaded_length()),
+                            .with_upload_length(g.get_uploaded_length())
+                            .with_upload_speed(0)
+                            .with_connections(g.options().split.unwrap_or(aria2_core::constants::DEFAULT_SPLIT) as u16),
                     );
                 }
             }
@@ -72,7 +74,10 @@ impl RpcEngine {
                         StatusInfo::new(&gid_hex)
                             .with_status(DownloadStatus::Waiting)
                             .with_total_length(total)
-                            .with_completed_length(completed),
+                            .with_completed_length(completed)
+                            .with_download_speed(0)
+                            .with_upload_speed(0)
+                            .with_connections(g.options().split.unwrap_or(aria2_core::constants::DEFAULT_SPLIT) as u16),
                     );
                 }
             }

--- a/aria2-rpc/src/handlers/status.rs
+++ b/aria2-rpc/src/handlers/status.rs
@@ -34,7 +34,12 @@ impl RpcEngine {
                             .with_download_speed(g.get_download_speed_cached())
                             .with_upload_length(g.get_uploaded_length())
                             .with_upload_speed(0)
-                            .with_connections(g.options().split.unwrap_or(aria2_core::constants::DEFAULT_SPLIT) as u16),
+                            .with_connections(
+                                g.options()
+                                    .split
+                                    .unwrap_or(aria2_core::constants::DEFAULT_SPLIT)
+                                    as u16,
+                            ),
                     );
                 }
             }
@@ -77,7 +82,12 @@ impl RpcEngine {
                             .with_completed_length(completed)
                             .with_download_speed(0)
                             .with_upload_speed(0)
-                            .with_connections(g.options().split.unwrap_or(aria2_core::constants::DEFAULT_SPLIT) as u16),
+                            .with_connections(
+                                g.options()
+                                    .split
+                                    .unwrap_or(aria2_core::constants::DEFAULT_SPLIT)
+                                    as u16,
+                            ),
                     );
                 }
             }

--- a/aria2-rpc/src/handlers/task.rs
+++ b/aria2-rpc/src/handlers/task.rs
@@ -9,6 +9,7 @@ use crate::engine::TaskState;
 use crate::json_rpc::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 use crate::types::{DownloadStatus, FileInfo, StatusInfo, create_gid};
 use crate::websocket::{DownloadEvent, EventType};
+use aria2_core::constants as core_constants;
 use aria2_core::engine::download_command::DownloadCommand;
 use aria2_core::request::request_group::{DownloadOptions, GroupId};
 
@@ -539,6 +540,8 @@ impl RpcEngine {
                         .with_completed_length(completed)
                         .with_upload_length(uploaded)
                         .with_download_speed(dl_speed)
+                        .with_upload_speed(0)
+                        .with_connections(g.options().split.unwrap_or(core_constants::DEFAULT_SPLIT) as u16)
                         .with_dir(dir)
                         .with_files(files),
                 );

--- a/aria2-rpc/src/handlers/task.rs
+++ b/aria2-rpc/src/handlers/task.rs
@@ -541,7 +541,9 @@ impl RpcEngine {
                         .with_upload_length(uploaded)
                         .with_download_speed(dl_speed)
                         .with_upload_speed(0)
-                        .with_connections(g.options().split.unwrap_or(core_constants::DEFAULT_SPLIT) as u16)
+                        .with_connections(
+                            g.options().split.unwrap_or(core_constants::DEFAULT_SPLIT) as u16,
+                        )
                         .with_dir(dir)
                         .with_files(files),
                 );

--- a/aria2-rpc/src/types.rs
+++ b/aria2-rpc/src/types.rs
@@ -29,6 +29,7 @@ pub type TaskOptions = Arc<RwLock<HashMap<String, HashMap<String, serde_json::Va
 /// and `aria2.tellStopped`. Contains both static metadata (GID, directory)
 /// and dynamic progress fields (speeds, lengths, connections).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StatusInfo {
     pub gid: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -150,6 +151,7 @@ impl StatusInfo {
 /// Returned by `aria2.getFiles`. Contains file path, size, progress,
 /// selection state, and associated URIs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FileInfo {
     pub index: usize,
     pub path: String,
@@ -195,6 +197,7 @@ impl FileInfo {
 ///
 /// Used in `FileInfo.uris` and returned by `aria2.getUris`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UriEntry {
     pub uri: String,
     pub status: UriStatus,
@@ -238,6 +241,7 @@ pub type UriInfo = UriEntry;
 ///
 /// Returned by `aria2.getServers`, grouped by file index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ServerInfoIndex {
     /// File index (0-based)
     pub index: usize,
@@ -249,6 +253,7 @@ pub struct ServerInfoIndex {
 ///
 /// Contains URI, current active URI (after redirects), and download speed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ServerInfo {
     /// Original server URI
     pub uri: String,
@@ -287,6 +292,7 @@ impl ServerInfo {
 /// Returned by `aria2.getPeers`. Contains peer connection state and
 /// transfer speeds.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PeerInfo {
     pub peer_id: String,
     pub ip: String,
@@ -373,6 +379,7 @@ impl VersionInfo {
 ///
 /// Contains session identifier and startup timestamp.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionInfo {
     /// Unique session identifier
     pub session_id: String,
@@ -550,10 +557,10 @@ mod tests {
 
         let serialized = serde_json::to_value(&info).unwrap();
         assert!(
-            serialized.get("torrent_files").is_some(),
-            "torrent_files should appear in JSON output"
+            serialized.get("torrentFiles").is_some(),
+            "torrentFiles should appear in JSON output"
         );
-        let tf_arr = serialized.get("torrent_files").unwrap().as_array().unwrap();
+        let tf_arr = serialized.get("torrentFiles").unwrap().as_array().unwrap();
         assert_eq!(tf_arr.len(), 2);
     }
 
@@ -569,13 +576,13 @@ mod tests {
             upload_speed: 512000,
         };
         let json = serde_json::to_value(&peer).unwrap();
-        assert_eq!(json["peer_id"], "peer-abc123");
+        assert_eq!(json["peerId"], "peer-abc123");
         assert_eq!(json["ip"], "192.168.1.100");
         assert_eq!(json["port"], 6881);
-        assert_eq!(json["am_choking"], false);
-        assert_eq!(json["peer_choking"], true);
-        assert_eq!(json["download_speed"], 1048576);
-        assert_eq!(json["upload_speed"], 512000);
+        assert_eq!(json["amChoking"], false);
+        assert_eq!(json["peerChoking"], true);
+        assert_eq!(json["downloadSpeed"], 1048576);
+        assert_eq!(json["uploadSpeed"], 512000);
 
         let roundtrip: PeerInfo = serde_json::from_value(json).unwrap();
         assert_eq!(roundtrip.port, 6881);

--- a/aria2-rpc/tests/test_rpc_headers_and_progress.rs
+++ b/aria2-rpc/tests/test_rpc_headers_and_progress.rs
@@ -171,9 +171,9 @@ async fn test_tell_status_returns_live_progress() {
     let status = resp.result.unwrap();
     assert_eq!(status["gid"], gid);
     assert_eq!(status["status"], "active");
-    assert_eq!(status["total_length"], 10_000_000);
-    assert_eq!(status["completed_length"], 4_200_000);
-    assert_eq!(status["download_speed"], 512_000);
+    assert_eq!(status["totalLength"], 10_000_000);
+    assert_eq!(status["completedLength"], 4_200_000);
+    assert_eq!(status["downloadSpeed"], 512_000);
 }
 
 // =========================================================================
@@ -292,8 +292,8 @@ async fn test_progress_changes_reflected_in_tell_status() {
     let tell1 = JsonRpcRequest::new("aria2.tellStatus", json!([gid.clone()])).with_id(2);
     let resp = engine.handle_request(&tell1).await;
     let s1 = resp.result.unwrap();
-    assert_eq!(s1["completed_length"], 100_000);
-    assert_eq!(s1["total_length"], 1_000_000);
+    assert_eq!(s1["completedLength"], 100_000);
+    assert_eq!(s1["totalLength"], 1_000_000);
 
     // Simulate more progress
     {
@@ -308,8 +308,8 @@ async fn test_progress_changes_reflected_in_tell_status() {
     let tell2 = JsonRpcRequest::new("aria2.tellStatus", json!([gid.clone()])).with_id(3);
     let resp = engine.handle_request(&tell2).await;
     let s2 = resp.result.unwrap();
-    assert_eq!(s2["completed_length"], 500_000, "progress should update");
-    assert_eq!(s2["download_speed"], 120_000, "speed should update");
+    assert_eq!(s2["completedLength"], 500_000, "progress should update");
+    assert_eq!(s2["downloadSpeed"], 120_000, "speed should update");
 }
 
 // =========================================================================

--- a/aria2/Cargo.toml
+++ b/aria2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aria2/src/app/mod.rs
+++ b/aria2/src/app/mod.rs
@@ -149,8 +149,14 @@ impl App {
 
             // After daemonization, we are in the child process
             // Re-initialize logging for the daemon process
-            let log_level = self.get_opt_str("log-level").await.unwrap_or_else(|| "info".to_string());
-            let console_log_level = self.get_opt_str("console-log-level").await.unwrap_or_else(|| "notice".to_string());
+            let log_level = self
+                .get_opt_str("log-level")
+                .await
+                .unwrap_or_else(|| "info".to_string());
+            let console_log_level = self
+                .get_opt_str("console-log-level")
+                .await
+                .unwrap_or_else(|| "notice".to_string());
             let log_path = self.get_opt_str("log").await;
             let log_backup_count = self.get_opt_i64("log-backup-count").await.unwrap_or(5) as usize;
             init_logging(
@@ -165,8 +171,14 @@ impl App {
 
         // In daemon mode, logging was already re-initialized after daemonization above.
         if !daemon_mode {
-            let log_level = self.get_opt_str("log-level").await.unwrap_or_else(|| "info".to_string());
-            let console_log_level = self.get_opt_str("console-log-level").await.unwrap_or_else(|| "notice".to_string());
+            let log_level = self
+                .get_opt_str("log-level")
+                .await
+                .unwrap_or_else(|| "info".to_string());
+            let console_log_level = self
+                .get_opt_str("console-log-level")
+                .await
+                .unwrap_or_else(|| "notice".to_string());
             let log_path = self.get_opt_str("log").await;
             let log_backup_count = self.get_opt_i64("log-backup-count").await.unwrap_or(5) as usize;
             init_logging(

--- a/aria2/src/app/mod.rs
+++ b/aria2/src/app/mod.rs
@@ -32,7 +32,7 @@ use aria2_core::config::ConfigManager;
 use aria2_core::init_logging;
 use aria2_core::request::request_group_man::RequestGroupMan;
 use aria2_core::validation::protocol_detector::DetectedInput;
-use tracing::{Level, info, warn};
+use tracing::{info, warn};
 
 // Daemon support (module declared in lib.rs as `pub mod daemon;`)
 use crate::daemon::{DaemonConfig, Daemonizer, PidFileManager};
@@ -91,8 +91,7 @@ impl App {
             colored::control::set_override(false);
         }
 
-        // Extract verbose before cli is consumed by load_cli_args
-        let verbose = cli.verbose;
+        // verbose is handled via log-level config option
 
         // Use --conf-path from CLI if provided, else fall back to default
         let conf_path = cli
@@ -131,12 +130,13 @@ impl App {
             }
 
             // Perform daemonization
-            let log_path = self.get_opt_str("log").await.map(PathBuf::from);
-
+            // Note: Do NOT pass log_path to stdout_file/stderr_file.
+            // File logging is handled by init_logging() below using rolling appender.
+            // Passing log_path here would create duplicate log files.
             let daemon_config = DaemonConfig {
                 pid_file: pid_file.clone(),
-                stdout_file: log_path.clone(),
-                stderr_file: log_path,
+                stdout_file: None,
+                stderr_file: None,
                 chdir_to_root: false,
                 close_fds: true,
             };
@@ -149,16 +149,33 @@ impl App {
 
             // After daemonization, we are in the child process
             // Re-initialize logging for the daemon process
-            let log_level = if verbose { Level::DEBUG } else { Level::INFO };
+            let log_level = self.get_opt_str("log-level").await.unwrap_or_else(|| "info".to_string());
+            let console_log_level = self.get_opt_str("console-log-level").await.unwrap_or_else(|| "notice".to_string());
             let log_path = self.get_opt_str("log").await;
-            init_logging(log_level, log_path.as_deref());
+            let log_backup_count = self.get_opt_i64("log-backup-count").await.unwrap_or(5) as usize;
+            init_logging(
+                &log_level,
+                &console_log_level,
+                log_path.as_deref(),
+                log_backup_count,
+            );
 
             info!("Daemon started successfully");
         }
 
-        let log_level = if verbose { Level::DEBUG } else { Level::INFO };
-        let log_path = self.get_opt_str("log").await;
-        init_logging(log_level, log_path.as_deref());
+        // In daemon mode, logging was already re-initialized after daemonization above.
+        if !daemon_mode {
+            let log_level = self.get_opt_str("log-level").await.unwrap_or_else(|| "info".to_string());
+            let console_log_level = self.get_opt_str("console-log-level").await.unwrap_or_else(|| "notice".to_string());
+            let log_path = self.get_opt_str("log").await;
+            let log_backup_count = self.get_opt_i64("log-backup-count").await.unwrap_or(5) as usize;
+            init_logging(
+                &log_level,
+                &console_log_level,
+                log_path.as_deref(),
+                log_backup_count,
+            );
+        }
 
         self.print_banner();
 

--- a/aria2/src/daemon.rs
+++ b/aria2/src/daemon.rs
@@ -337,7 +337,9 @@ impl Daemonizer {
             std::env::current_exe().inspect_err(|e| error!("Failed to get exe path: {e}"))?;
 
         // Get current arguments (excluding the program name)
-        let args: Vec<String> = std::env::args().skip(1).collect();
+        let args: Vec<String> = std::env::args().skip(1)
+            .filter(|arg| arg != "--daemon" && arg != "-D")
+            .collect();
 
         // Build the command for the detached process
         let mut cmd = Command::new(&exe_path);

--- a/aria2/src/daemon.rs
+++ b/aria2/src/daemon.rs
@@ -337,7 +337,8 @@ impl Daemonizer {
             std::env::current_exe().inspect_err(|e| error!("Failed to get exe path: {e}"))?;
 
         // Get current arguments (excluding the program name)
-        let args: Vec<String> = std::env::args().skip(1)
+        let args: Vec<String> = std::env::args()
+            .skip(1)
             .filter(|arg| arg != "--daemon" && arg != "-D")
             .collect();
 


### PR DESCRIPTION
## Summary

- Complete reqwest 0.11 to 0.13.4 upgrade and hyper 0.14 to 1.x migration
- Fix blocking_read deadlock risk in DHT engine (11 sync shutdown calls changed to shutdown_async)
- Fix full_body parameter shadowing bug (E0618) in mock HTTP server
- Add partial_body helper for hyper 1.x Content-Length compatibility
- Switch from shared workspace version to independent per-crate versioning
- Bump all crates 0.2.1 to 0.2.2

## Changes

### reqwest 0.13.4 upgrade (aria2-core, aria2-protocol)
- Feature rename rustls-tls to rustls
- content_length returns None for HEAD responses; added workaround reading CONTENT_LENGTH header directly
- Timeout errors wrapped in decoding response body; use is_timeout (walks error chain) instead of string matching

### hyper 1.x migration (aria2-core)
- Replaced hyper Body/Client/Server with hyper-util, http-body-util, http
- Empty has size_hint Exact(0), causing hyper 1.x to override Content-Length; added partial_body using StreamBody (Unknown size_hint)

### Concurrency fix (aria2-protocol)
- DhtEngine::shutdown uses blocking_read which can deadlock in async contexts
- Changed 11 sync shutdown calls to shutdown_async await in DHT engine tests
- Added doc warning to sync shutdown method

### Versioning
- Independent per-crate versions (libraries published to crates.io individually)
- workspace.metadata.release: shared-version=false, consolidate-commits=false

## Test plan

- [x] cargo check workspace lib (passes)
- [x] cargo check aria2-core tests (passes)
- [x] cargo check aria2-protocol with bittorrent feature (passes)
- [x] cargo test aria2-core lib (1236 passed)
- [x] cargo test aria2-core E2E suites (97 passed across 9 suites)
- [x] cargo test aria2-protocol bittorrent DHT (137 passed)
- [x] cargo test aria2-protocol lib (63 passed)
- [ ] CI pipeline (awaiting results)