### PR TITLE
chore: bump version to v0.2.3, add master-branch guard to publish/release workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── Branch guard: only master branch can publish ────────────
+  check-branch:
+    name: Check tag is on master
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on master
+        run: |
+          git fetch origin master
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "ERROR: Tag must be on master branch"
+            exit 1
+          fi
+          echo "Tag is on master, proceeding..."
+
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    needs: [check-branch]
     
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,30 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── Branch guard: only master branch can release ────────────
+  check-branch:
+    name: Check tag is on master
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on master
+        run: |
+          git fetch origin master
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/master; then
+            echo "ERROR: Tag must be on master branch"
+            exit 1
+          fi
+          echo "Tag is on master, proceeding..."
+
   # Job 1: Check whether optional publish secrets are configured.
   # GitHub Actions cannot read secrets directly in `if:` conditions, so this
   # job exports boolean outputs that downstream bindings publish jobs gate on.
   check-secrets:
     name: Check secrets
     runs-on: ubuntu-latest
+    needs: [check-branch]
     outputs:
       has_pypi: ${{ steps.check.outputs.has_pypi }}
       has_npm: ${{ steps.check.outputs.has_npm }}
@@ -31,6 +49,7 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    needs: [check-branch]
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +105,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [check-branch, build]
     permissions:
       contents: write
     steps:
@@ -132,7 +151,7 @@ jobs:
   publish-python:
     name: Publish Python SDK
     runs-on: ubuntu-latest
-    needs: [github-release, check-secrets]
+    needs: [check-branch, github-release, check-secrets]
     if: needs.check-secrets.outputs.has_pypi == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -159,7 +178,7 @@ jobs:
   publish-nodejs:
     name: Publish Node.js SDK
     runs-on: ubuntu-latest
-    needs: [github-release, check-secrets]
+    needs: [check-branch, github-release, check-secrets]
     if: needs.check-secrets.outputs.has_npm == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -186,7 +205,7 @@ jobs:
   docker:
     name: Docker Image
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [check-branch, build]
     permissions:
       packages: write
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "aria2"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aria2-core",
  "aria2-protocol",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "adler32",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-rpc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "aria2-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["aria2-rust contributors"]
 license = "GPL-2.0-or-later"

--- a/aria2-core/Cargo.toml
+++ b/aria2-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-core"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aria2-protocol/Cargo.toml
+++ b/aria2-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-protocol"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aria2-rpc/Cargo.toml
+++ b/aria2-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-rpc"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aria2/Cargo.toml
+++ b/aria2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Master branch guard: verify tag is on master before publish/release
- Bump all crate versions to 0.2.3 for re-publish

No code logic changes - only workflow config and version bump.