### PR TITLE
ci: trigger binary releases directly from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,10 +1,8 @@
 name: Release Binaries
 
 on:
-  workflow_run:
-    workflows: [CI]
+  push:
     branches: [master]
-    types: [completed]
 
 permissions:
   contents: write
@@ -16,17 +14,16 @@ concurrency:
 jobs:
   prepare:
     name: Prepare binary release
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.release.outputs.should_release }}
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
-      sha: ${{ github.event.workflow_run.head_sha }}
+      sha: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - id: release
         shell: bash


### PR DESCRIPTION
## Summary
- Run CI only for pull requests targeting master.
- Trigger binary releases directly from pushes to master.

## Release impact
- A merge to master starts the binary release workflow without running test CI on master.