### PR TITLE
fix: publish Node.js package under organization scope

### DIFF
--- a/bindings/nodejs/package-lock.json
+++ b/bindings/nodejs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aria2-rust",
+  "name": "@aria2-rust/aria2-rust",
   "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aria2-rust",
+      "name": "@aria2-rust/aria2-rust",
       "version": "0.3.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aria2-rust",
+  "name": "@aria2-rust/aria2-rust",
   "version": "0.3.0",
   "description": "Production-grade Node.js client for aria2-rust JSON-RPC & WebSocket interface",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary\n- publish the Node.js SDK as @aria2-rust/aria2-rust\n- align package metadata with the configured @aria2-rust token scope\n\n## Testing\n- npm package metadata verified locally\n- CI is manual-only by repository policy