### PR TITLE
fix: make Docker publishing resilient

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Publish Docker image (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Image version without the leading v (for example, 0.3.6)
+        required: true
+        type: string
+      publish_latest:
+        description: Also update the latest tag
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: master
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=v${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.publish_latest }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+          platforms: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,7 +372,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache export is best-effort; a cache quota/reservation failure must
+          # not fail an image that was already pushed to GHCR.
+          cache-to: type=gha,mode=max,ignore-error=true
           platforms: linux/amd64
 
   github-release:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ docs/MIGRATION.md
 
 # Ignore local/tooling directories whose names start with a dot.
 .*/
+!.github/
+!.github/workflows/


### PR DESCRIPTION
Make GHCR cache export best-effort so cache reservation failures do not fail image publishing. Add a standalone manual Docker workflow for republishing a selected version and latest tag.